### PR TITLE
Fix shell name capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Chronos is airbnb's replacement for `cron`.
 It is a distributed and fault-tolerant scheduler which runs on top of [mesos][mesos]. It's a framework and supports custom
-[mesos][mesos] executors as well as the default command executor. Thus by default, Chronos executes SH (on most systems BASH) scripts.
+[mesos][mesos] executors as well as the default command executor. Thus by default, Chronos executes sh (on most systems bash) scripts.
 Chronos can be used to interact with systems such as Hadoop (incl. EMR), even if the mesos slaves on which execution happens
 do not have Hadoop installed. Included wrapper scripts allow transfering files and executing them on a remote machine in the background
 and using asynchronous callbacks to notify Chronos of job completion or failures.


### PR DESCRIPTION
"SH" and "BASH" just look unnatural. Updating to reflect common usage.
