### PR TITLE
One step install for Ubuntu

### DIFF
--- a/bin/ubuntu.bash
+++ b/bin/ubuntu.bash
@@ -6,6 +6,9 @@ cat <<USAGE
 
   Installs Chronos in one step.
 
+  Installs all deb packages, downloads and builds Mesos and Chronos from
+  Github and then installs a Chronos wrapper in $prefix/bin.
+
 USAGE
 }; function --help { -h ;}
 


### PR DESCRIPTION
This has some limitations and omissions:
- It always installs both Mesos and Chronos in `/usr/local`.
- There is no Upstart script.
- The `chronos` wrapper doesn't allow passing anything other than a config file.

Would be interested to see if this installer is helpful in practice.
