### PR TITLE
[bugfix] Fixes exceptional case in JobScheduler

### DIFF
--- a/src/main/scala/com/airbnb/scheduler/api/TaskManagementResource.scala
+++ b/src/main/scala/com/airbnb/scheduler/api/TaskManagementResource.scala
@@ -40,7 +40,7 @@ class TaskManagementResource @Inject()(
   def updateStatus(@PathParam("id") id: String, taskNotification: TaskNotification): Response = {
     log.info("Update request received")
     try {
-      log.info("Received update for asynchroneous taskId: %s, statusCode: %d".format(id, taskNotification.statusCode))
+      log.info("Received update for asynchronous taskId: %s, statusCode: %d".format(id, taskNotification.statusCode))
 
       if (taskNotification.statusCode == 0) {
         log.info("Task completed successfully '%s'".format(id))

--- a/src/main/scala/com/airbnb/scheduler/graph/JobGraph.scala
+++ b/src/main/scala/com/airbnb/scheduler/graph/JobGraph.scala
@@ -136,7 +136,7 @@ class JobGraph {
             edgeInvocationCount.put(currentEdge, edgeInvocationCount.get(currentEdge).get + 1)
           }
           val count = edgeInvocationCount.get(currentEdge).get
-          var min = edgesToChild.map(edgeInvocationCount.getOrElse(_, 0L)).min
+          val min = edgesToChild.map(edgeInvocationCount.getOrElse(_, 0L)).min
           if (count == min)
             results += child
         }

--- a/src/main/scala/com/airbnb/scheduler/mesos/MesosJobFramework.scala
+++ b/src/main/scala/com/airbnb/scheduler/mesos/MesosJobFramework.scala
@@ -136,7 +136,7 @@ class MesosJobFramework @Inject()(
             Protos.Value.Scalar.newBuilder()
               .setValue(x.getScalar.getValue / math.max(x.getScalar.getValue, 1))).setName(x.getName))
       } else {
-        log.warning("Ignoring offered resource:" + x.getType)
+        log.warning("Ignoring offered resource: %s".format(x.getType.toString))
       })
 
     val mesosTask = taskInfoTemplate.setSlaveId(offer.getSlaveId).build()


### PR DESCRIPTION
# CHANGELOG
- Patched an exceptional case in `JobScheduler` that could cause
  `MesosJobFramework` to reach a non-sane and unrecoverable state.
- Corrected spelling in `TaskManagementResource` log message
- Converted erroneous `var` to `val` in `JobGraph`.
- Various light style fixes and cleanup.

/cc @florianleibert 
