### PR TITLE
[assets][scheduler] Minor bugfixes. See changelog below

### DIFF
--- a/src/main/resources/assets/app/scripts/templates/job_detail_view.hbs
+++ b/src/main/resources/assets/app/scripts/templates/job_detail_view.hbs
@@ -46,7 +46,6 @@
         <div class="field cmd">
           <input class="job-input"
                  value="{{joinWith parents ', '}}"
-                 data-rv-value="job:parentsList < .parents"
                  placeholder="Choose parents..."
                  data-placeholder="Choose parents..."
                  name="parents"

--- a/src/main/scala/com/airbnb/scheduler/api/JobsDeserializer.scala
+++ b/src/main/scala/com/airbnb/scheduler/api/JobsDeserializer.scala
@@ -4,6 +4,7 @@ import com.airbnb.scheduler.jobs.{BaseJob, DependencyBasedJob, ScheduleBasedJob}
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.{JsonNode, DeserializationContext, JsonDeserializer}
 import org.joda.time.Period
+import scala.collection.JavaConversions._
 
 /**
  * Custom JSON deserializer for jobs.
@@ -60,16 +61,15 @@ class JobsDeserializer extends JsonDeserializer[BaseJob] {
 
     var parentList = scala.collection.mutable.ListBuffer[String]()
     if (node.has("parents")) {
-      import scala.collection.JavaConversions._
       for (parent <- node.path("parents")) {
         parentList += parent.asText
       }
-      return new DependencyBasedJob(parents = parentList.toList,
+      new DependencyBasedJob(parents = parentList.toSet,
         name = name, command = command, epsilon = epsilon, successCount = successCount, errorCount = errorCount,
         executor = executor, executorFlags = executorFlags, retries = retries, owner = owner, lastError = lastError,
         lastSuccess = lastSuccess, async = async)
     } else if (node.has("schedule")) {
-      return new ScheduleBasedJob(node.get("schedule").asText, name = name, command = command,
+      new ScheduleBasedJob(node.get("schedule").asText, name = name, command = command,
         epsilon = epsilon, successCount = successCount, errorCount = errorCount, executor = executor,
         executorFlags = executorFlags, retries = retries, owner = owner, lastError = lastError,
         lastSuccess = lastSuccess, async = async)

--- a/src/main/scala/com/airbnb/scheduler/jobs/Jobs.scala
+++ b/src/main/scala/com/airbnb/scheduler/jobs/Jobs.scala
@@ -56,7 +56,8 @@ case class ScheduleBasedJob(
 
 
 @JsonDeserialize(using = classOf[JobsDeserializer])
-case class DependencyBasedJob(@JsonProperty parents: List[String],
+case class DependencyBasedJob(
+    @JsonProperty parents: Set[String],
     @JsonProperty override val name: String,
     @JsonProperty override val command: String,
     @JsonProperty override val epsilon: Period = Minutes.minutes(5).toPeriod,

--- a/src/test/scala/com/airbnb/scheduler/api/SerDeTest.scala
+++ b/src/test/scala/com/airbnb/scheduler/api/SerDeTest.scala
@@ -16,8 +16,8 @@ class SerDeTest extends SpecificationWithJUnit {
       mod.addDeserializer(classOf[BaseJob], new JobsDeserializer)
       objectMapper.registerModule(mod)
 
-      val a = new DependencyBasedJob(List("B", "C", "D", "E"), "A", "noop", Minutes.minutes(5).toPeriod, 10L, 20L,
-        "fooexec", "fooflags", 7, "foo@bar.com", "TODAY", "YESTERDAY", true)
+      val a = new DependencyBasedJob(Set("B", "C", "D", "E"), "A", "noop", Minutes.minutes(5).toPeriod, 10L,
+        20L, "fooexec", "fooflags", 7, "foo@bar.com", "TODAY", "YESTERDAY", true)
 
       val aStr = objectMapper.writeValueAsString(a)
       val aCopy = objectMapper.readValue(aStr, classOf[DependencyBasedJob])

--- a/src/test/scala/com/airbnb/scheduler/jobs/JobSchedulerSpec.scala
+++ b/src/test/scala/com/airbnb/scheduler/jobs/JobSchedulerSpec.scala
@@ -243,7 +243,7 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     val jobStream = new ScheduleStream("R/2012-01-01T00:00:00.000Z/PT1S", jobName)
     val scheduler = new JobScheduler(Period.hours(1), mock[TaskManager], mockGraph, store)
 
-    var startTime = DateTime.parse("2012-01-01T00:00:00.000Z")
+    val startTime = DateTime.parse("2012-01-01T00:00:00.000Z")
     var t: DateTime = startTime
     var stream = scheduler.iteration(startTime, List(jobStream))
     t = t.plus(Period.millis(1).toPeriod)
@@ -256,10 +256,10 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
   "Recursive removing of jobs works" in {
     val epsilon = Seconds.seconds(60).toPeriod
     val job1 = new ScheduleBasedJob("R/2012-01-01T00:00:00.000Z/PT1M", "job1", "CMD", epsilon)
-    val job2 = new DependencyBasedJob(List("job1"), name = "job2", command = "CMD")
-    val job3 = new DependencyBasedJob(List("job2"), name = "job3", command = "CMD")
-    val job4 = new DependencyBasedJob(List("job3"), name = "job4", command = "CMD")
-    val job5 = new DependencyBasedJob(List("job4"), name = "job5", command = "CMD")
+    val job2 = new DependencyBasedJob(Set("job1"), name = "job2", command = "CMD")
+    val job3 = new DependencyBasedJob(Set("job2"), name = "job3", command = "CMD")
+    val job4 = new DependencyBasedJob(Set("job3"), name = "job4", command = "CMD")
+    val job5 = new DependencyBasedJob(Set("job4"), name = "job5", command = "CMD")
 
     val mockTaskManager = mock[TaskManager]
     val jobGraph = new JobGraph
@@ -288,10 +288,10 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
   "Removing a dependency of another job throws an exception without the force method" in {
     val epsilon = Seconds.seconds(60).toPeriod
     val job1 = new ScheduleBasedJob("R/2012-01-01T00:00:00.000Z/PT1M", "job1", "CMD", epsilon)
-    val job2 = new DependencyBasedJob(List("job1"), name = "job2", command = "CMD")
-    val job3 = new DependencyBasedJob(List("job2"), name = "job3", command = "CMD")
-    val job4 = new DependencyBasedJob(List("job3"), name = "job4", command = "CMD")
-    val job5 = new DependencyBasedJob(List("job4"), name = "job5", command = "CMD")
+    val job2 = new DependencyBasedJob(Set("job1"), name = "job2", command = "CMD")
+    val job3 = new DependencyBasedJob(Set("job2"), name = "job3", command = "CMD")
+    val job4 = new DependencyBasedJob(Set("job3"), name = "job4", command = "CMD")
+    val job5 = new DependencyBasedJob(Set("job4"), name = "job5", command = "CMD")
 
     val mockTaskManager = mock[TaskManager]
     val jobGraph = new JobGraph
@@ -316,9 +316,9 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     val epsilon = Seconds.seconds(60).toPeriod
     val job1 = new ScheduleBasedJob("R/2012-01-01T00:00:00.000Z/PT1M", "job1", "CMD", epsilon)
     val job2 = new ScheduleBasedJob("R/2012-01-01T00:00:00.000Z/PT1M", "job2", "CMD", epsilon)
-    val job3 = new DependencyBasedJob(List("job2"), name = "job3", command = "CMD")
-    val job4 = new DependencyBasedJob(List("job1"), name = "job4", command = "CMD")
-    val job5 = new DependencyBasedJob(List("job1", "job3"), name = "job5", command = "CMD")
+    val job3 = new DependencyBasedJob(Set("job2"), name = "job3", command = "CMD")
+    val job4 = new DependencyBasedJob(Set("job1"), name = "job4", command = "CMD")
+    val job5 = new DependencyBasedJob(Set("job1", "job3"), name = "job5", command = "CMD")
 
     val mockTaskManager = mock[TaskManager]
     val jobGraph = new JobGraph
@@ -340,7 +340,7 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     scheduler.jobGraph.lookupVertex("job2")  must_== None
     scheduler.jobGraph.lookupVertex("job3")  must_== None
     scheduler.jobGraph.lookupVertex("job5").get.asInstanceOf[DependencyBasedJob].parents.size must_== 1
-    scheduler.jobGraph.lookupVertex("job5").get.asInstanceOf[DependencyBasedJob].parents must_== List("job1")
+    scheduler.jobGraph.lookupVertex("job5").get.asInstanceOf[DependencyBasedJob].parents must_== Set("job1")
   }
 
   "Missed executions have to be skipped" in {

--- a/src/test/scala/com/airbnb/scheduler/jobs/graph/JobGraphSpec.scala
+++ b/src/test/scala/com/airbnb/scheduler/jobs/graph/JobGraphSpec.scala
@@ -10,8 +10,8 @@ class JobGraphSpec extends SpecificationWithJUnit with Mockito {
 
   "JobGraph" should {
     "Adding a parent and child to the graph works as expected" in {
-      val a = new DependencyBasedJob(List(), "A", "noop")
-      val b = new DependencyBasedJob(List(), "B", "noop")
+      val a = new DependencyBasedJob(Set(), "A", "noop")
+      val b = new DependencyBasedJob(Set(), "B", "noop")
       val g = new JobGraph()
       g.addVertex(a)
       g.addVertex(b)
@@ -20,9 +20,9 @@ class JobGraphSpec extends SpecificationWithJUnit with Mockito {
     }
 
     "Adding a circular dependency should not be allowed" in {
-      val a = new DependencyBasedJob(List(), "A", "noop")
-      val b = new DependencyBasedJob(List(), "B", "noop")
-      val c = new DependencyBasedJob(List(), "C", "noop")
+      val a = new DependencyBasedJob(Set(), "A", "noop")
+      val b = new DependencyBasedJob(Set(), "B", "noop")
+      val c = new DependencyBasedJob(Set(), "C", "noop")
       val g = new JobGraph()
       g.addVertex(a)
       g.addVertex(b)
@@ -33,26 +33,26 @@ class JobGraphSpec extends SpecificationWithJUnit with Mockito {
     }
 
     "Adding nodes with the same name should not be allowed" in {
-      val a = new DependencyBasedJob(List(), "A", "noop")
-      val b = new DependencyBasedJob(List(), "A", "noop")
+      val a = new DependencyBasedJob(Set(), "A", "noop")
+      val b = new DependencyBasedJob(Set(), "A", "noop")
       val g = new JobGraph()
       g.addVertex(a)
       g.addVertex(b) must throwA[Exception]
     }
 
     "Adding the same edge twice is idempotent" in {
-      val a = new DependencyBasedJob(List(), "A", "noop")
-      val b = new DependencyBasedJob(List(), "A", "noop")
+      val a = new DependencyBasedJob(Set(), "A", "noop")
+      val b = new DependencyBasedJob(Set(), "A", "noop")
       val g = new JobGraph()
       g.addVertex(a)
       g.addVertex(b) must throwA[Exception]
     }
 
     "Adding dependencies should create proper edges" in {
-      val a = new DependencyBasedJob(List(), "A", "noop")
-      val b = new DependencyBasedJob(List(), "B", "noop")
-      val c = new DependencyBasedJob(List(), "C", "noop")
-      val d = new DependencyBasedJob(List(), "D", "noop")
+      val a = new DependencyBasedJob(Set(), "A", "noop")
+      val b = new DependencyBasedJob(Set(), "B", "noop")
+      val c = new DependencyBasedJob(Set(), "C", "noop")
+      val d = new DependencyBasedJob(Set(), "D", "noop")
       val g = new JobGraph()
       g.addVertex(a)
       g.addVertex(b)
@@ -73,11 +73,11 @@ class JobGraphSpec extends SpecificationWithJUnit with Mockito {
        *      /
        * C --
        */
-      val a = new DependencyBasedJob(List(), "A", "noop")
-      val b = new DependencyBasedJob(List(), "B", "noop")
-      val c = new DependencyBasedJob(List(), "C", "noop")
-      val d = new DependencyBasedJob(List(), "D", "noop")
-      val e = new DependencyBasedJob(List(), "E", "noop")
+      val a = new DependencyBasedJob(Set(), "A", "noop")
+      val b = new DependencyBasedJob(Set(), "B", "noop")
+      val c = new DependencyBasedJob(Set(), "C", "noop")
+      val d = new DependencyBasedJob(Set(), "D", "noop")
+      val e = new DependencyBasedJob(Set(), "E", "noop")
       val graph = new JobGraph()
       graph.addVertex(a)
       graph.addVertex(b)
@@ -109,10 +109,10 @@ class JobGraphSpec extends SpecificationWithJUnit with Mockito {
     }
 
     "Replacing a vertex works" in {
-      val a = new DependencyBasedJob(List(), "A", "noopA")
-      val b = new DependencyBasedJob(List(), "B", "noopB")
-      val c = new DependencyBasedJob(List(), "C", "noopC")
-      val d = new DependencyBasedJob(List(), "C", "noopD")
+      val a = new DependencyBasedJob(Set(), "A", "noopA")
+      val b = new DependencyBasedJob(Set(), "B", "noopB")
+      val c = new DependencyBasedJob(Set(), "C", "noopC")
+      val d = new DependencyBasedJob(Set(), "C", "noopD")
 
       val graph = new JobGraph()
       graph.addVertex(a)


### PR DESCRIPTION
# CHANGELOG
- Remove rivets binding from the parents input field in
  `job_detail_view.hbs`, the `JobDetailView` template since data updates
  are handled by `select2`.
- Update `DependencyBasedJob#parents` representation to be `Set[String]`,
  rather than a `List[String]`
- Update tests to account for changes to `DependencyBasedJob#parents`
