### PR TITLE
Mesos installer git clone method

### DIFF
--- a/bin/install_mesos.bash
+++ b/bin/install_mesos.bash
@@ -22,7 +22,7 @@ function all {
     fi
     popd
   else
-    git clone git@github.com:apache/incubator-mesos.git $source_dir
+    git clone https://github.com/apache/incubator-mesos.git $source_dir
     (cd $source_dir
       git checkout $git_revision -b $branch_name
     )


### PR DESCRIPTION
Users that do try to install Mesos via the install_mesos.bash script reach a failure state if they do not have their public ssh keys on GitHub. Using an HTTPS git clone method will remove that requirement.
