### PR TITLE
Removed last "/" from mesosphere-public-repo URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <repository>
             <id>mesosphere-public-repo</id>
             <name>Mesosphere Public Snapshot Repo</name>
-            <url>http://s3.amazonaws.com/mesosphere-maven-public/</url>
+            <url>http://s3.amazonaws.com/mesosphere-maven-public</url>
         </repository>
         <repository>
             <id>libs-folder</id>


### PR DESCRIPTION
Small change. mesoshpere-maven-public does not allow "//", so I can't build chronos.

```
$ curl -v http://s3.amazonaws.com/mesosphere-maven-public//org/apache/mesos/mesos/0.14.1-SNAPSHOT/maven-metadata.xml
* About to connect() to s3.amazonaws.com port 80 (#0)
*   Trying 207.171.189.80...
* connected
* Connected to s3.amazonaws.com (207.171.189.80) port 80 (#0)
> GET /mesosphere-maven-public//org/apache/mesos/mesos/0.14.1-SNAPSHOT/maven-metadata.xml HTTP/1.1
> User-Agent: curl/7.24.0 (x86_64-apple-darwin12.0) libcurl/7.24.0 OpenSSL/0.9.8x zlib/1.2.5
> Host: s3.amazonaws.com
> Accept: */*
>
< HTTP/1.1 404 Not Found
< x-amz-request-id: F882C9F5DB8112BF
< x-amz-id-2: YqMbcbQw/QrzsKgpzrMOPgpur3dp8zOlHghDSgp8XfgyOWQDdjxNRazD8hqMdSKw
< Content-Type: application/xml
< Transfer-Encoding: chunked
< Date: Tue, 06 Aug 2013 00:23:50 GMT
< Server: AmazonS3
```
