### PR TITLE
Removing a unit test that fails on JDK 6

### DIFF
--- a/src/test/scala/com/airbnb/scheduler/jobs/JobSchedulerIntegrationTest.scala
+++ b/src/test/scala/com/airbnb/scheduler/jobs/JobSchedulerIntegrationTest.scala
@@ -11,40 +11,41 @@ import com.google.common.util.concurrent.MoreExecutors
 class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
 
   "JobScheduler" should {
-    "A job creates a failed task and then a successful task from a synchronous job" in {
-      val epsilon = Hours.hours(2).toPeriod
-      val job1 = new ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD", epsilon)
-
-      val exec = MoreExecutors.listeningDecorator(new ScheduledThreadPoolExecutor(1))
-
-      val jobGraph = new JobGraph
-      val persistenceStore = mock[PersistenceStore]
-      val taskManager = new TaskManager(exec, persistenceStore, jobGraph, null)
-
-      val scheduler = new JobScheduler(epsilon, taskManager, jobGraph, persistenceStore, jobMetrics = mock[JobMetrics])
-      val startTime = DateTime.parse("2012-01-01T01:00:00.000Z")
-      scheduler.leader.set(true)
-      scheduler.registerJob(job1, true, startTime)
-
-      val newStreams = scheduler.iteration(startTime, scheduler.streams)
-      newStreams(0).schedule must_== "R4/2012-01-02T00:00:00.000Z/P1D"
-      taskManager.queue.size must_== 1
-
-      val taskId1 = taskManager.queue.poll
-
-      scheduler.handleFailedTask(taskId1)
-
-      taskManager.queue.size must_== 1
-
-      val taskId2 = taskManager.queue.poll
-
-      scheduler.handleFinishedTask(taskId2)
-      there was one(persistenceStore)
-        .persistJob(new ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD", epsilon))
-
-      there was one(persistenceStore)
-        .persistJob(new ScheduleBasedJob("R4/2012-01-02T00:00:00.000Z/P1D", "job1", "CMD", epsilon))
-    }
+//    Commented out as this doesn't work in OpenJDK6
+//    "A job creates a failed task and then a successful task from a synchronous job" in {
+//      val epsilon = Hours.hours(2).toPeriod
+//      val job1 = new ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD", epsilon)
+//
+//      val exec = MoreExecutors.listeningDecorator(new ScheduledThreadPoolExecutor(1))
+//
+//      val jobGraph = new JobGraph
+//      val persistenceStore = mock[PersistenceStore]
+//      val taskManager = new TaskManager(exec, persistenceStore, jobGraph, null)
+//
+//      val scheduler = new JobScheduler(epsilon, taskManager, jobGraph, persistenceStore, jobMetrics = mock[JobMetrics])
+//      val startTime = DateTime.parse("2012-01-01T01:00:00.000Z")
+//      scheduler.leader.set(true)
+//      scheduler.registerJob(job1, true, startTime)
+//
+//      val newStreams = scheduler.iteration(startTime, scheduler.streams)
+//      newStreams(0).schedule must_== "R4/2012-01-02T00:00:00.000Z/P1D"
+//      taskManager.queue.size must_== 1
+//
+//      val taskId1 = taskManager.queue.poll
+//
+//      scheduler.handleFailedTask(taskId1)
+//
+//      taskManager.queue.size must_== 1
+//
+//      val taskId2 = taskManager.queue.poll
+//
+//      scheduler.handleFinishedTask(taskId2)
+//      there was one(persistenceStore)
+//        .persistJob(new ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD", epsilon))
+//
+//      there was one(persistenceStore)
+//        .persistJob(new ScheduleBasedJob("R4/2012-01-02T00:00:00.000Z/P1D", "job1", "CMD", epsilon))
+//    }
 
     "Executing a job updates the job counts and errors" in {
       val epsilon = Minutes.minutes(20).toPeriod


### PR DESCRIPTION
This causes a bunch of people to give up trying out chronos. Let's migrate all of this to regular JUnit & scalamock instead and leave it out for now.
