### PR TITLE
Removes dynamic dependency graph, combines static and stats view.

### DIFF
--- a/src/main/resources/assets/app/scripts/templates/graph_view.hbs
+++ b/src/main/resources/assets/app/scripts/templates/graph_view.hbs
@@ -15,29 +15,4 @@
     <div id="graph-area"></div>
   </div>
 
-  <div class="btn-group graph-toggle" data-toggle="buttons-radio">
-    <button type="button"
-            class="btn {{active currentView 'dynamic'}}"
-            data-job-type="dynamic">Dynamic</button>
-    <button type="button"
-            class="btn {{active currentView 'static'}}"
-            data-job-type="static">Static</button>
-    <button type="button"
-            class="btn {{active currentView 'static-stats'}}"
-            data-job-type="static"
-            data-job-options='{"decorator": "stats"}'>Stats</button>
-    <!--
-    <button class="btn dropdown-toggle {{active currentView 'static'}}"
-            data-toggle="dropdown">
-      <span class="caret"></span>
-    </button>
-    <ul class="dropdown-menu">
-      <li class="" data-job-type="dynamic">
-        <a href="#">Stats View</a>
-      </li>
-      <li class="" data-job-type="dynamic">
-        <a href="#">Time View</a>
-      </li>
-    </ul> //-->
-  </div>
 </div>

--- a/src/main/resources/assets/app/scripts/views/application_view.js
+++ b/src/main/resources/assets/app/scripts/views/application_view.js
@@ -56,7 +56,7 @@ function($,
 
       $target    = $(e.currentTarget);
       targetName = $target.data('job-id');
-      graphType = $target.hasClass('view-alt-graph') ? 'static' : 'dynamic';
+      graphType = 'static';
       app.lightbox.showGraphView(graphType, targetName);
     },
 

--- a/src/main/resources/assets/app/scripts/views/graph_view.js
+++ b/src/main/resources/assets/app/scripts/views/graph_view.js
@@ -42,7 +42,7 @@ function(Backbone,
 
     getTemplateData: function() {
       return {
-        currentView: 'dynamic'
+        currentView: 'static-stats'
       };
     },
 

--- a/src/main/resources/assets/app/scripts/views/graphbox_view.js
+++ b/src/main/resources/assets/app/scripts/views/graphbox_view.js
@@ -29,7 +29,6 @@ define([
     initialize: function() {
       lbInitialize.apply(this, slice.call(arguments));
       this._graphTypes = {
-        'dynamic': GraphView,
         'static': GraphVizView
       };
     },


### PR DESCRIPTION
Removes the UI interaction in the dependency graph that allows users to view the dynamic dependency graph. Does not actually remove the dynamic graph code from the codebase. Also removes "static" graph, opting for the "static-stats" graph (a strict superset of the functionality).

Tested on my local chronos installation:
![ui_removed_graph](https://f.cloud.github.com/assets/525770/927894/989cdc34-ffa8-11e2-930d-c34c54df904d.png)

@hcai @andykram @brndnmtthws 
