### PR TITLE
Relocates destroy button.

### DIFF
--- a/src/main/resources/assets/app/scripts/views/job_detail_header_view.js
+++ b/src/main/resources/assets/app/scripts/views/job_detail_header_view.js
@@ -64,9 +64,9 @@ function($,
     'delete': function() {
       var model = this.model,
           view  = this,
-          destroy = prompt('Are you sure you want to destroy: ' + model.get('name') + '?\n Please enter "yes" to confirm.', '');
+          destroy = confirm('Are you sure you want to destroy: ' + model.get('name') + '?');
 
-      if (destroy == 'yes') {
+      if (destroy) {
         console.log('destroy')
 
         model.destroy({


### PR DESCRIPTION
Prevents accidental job destruction by moving job destroy button away from the close-job-detail button (at larger widths, this close-job-detail button appears, but at smaller widths, it does not). 

@hcai 
