### PR TITLE
Changes the background of last-run-status to grey for disabled jobs

### DIFF
--- a/src/main/resources/assets/app/scripts/styles/chronos.less
+++ b/src/main/resources/assets/app/scripts/styles/chronos.less
@@ -106,6 +106,10 @@ html > body .tooltip,
   &.count-error {
     background-color: rgba(157,38,29,0.6);
   }
+
+  &.count-disabled {
+    background-color: rgba(163,163,163,0.6);
+  }
 }
 
 .joblist .span1.ignore,

--- a/src/main/resources/assets/app/scripts/styles/core.less
+++ b/src/main/resources/assets/app/scripts/styles/core.less
@@ -511,6 +511,11 @@ margin-top: -70px;
   margin-bottom: 1px;
 }
 
+.item.disabled {
+  color: rgba(255,255,255,0.2);
+  background-color: rgba(255,255,255,0.05);
+}
+
 .item.active {
   color: rgba(255,255,255,1);
   background-color: rgba(107,174,214,0.7);

--- a/src/main/resources/assets/app/scripts/templates/job_item_view.hbs
+++ b/src/main/resources/assets/app/scripts/templates/job_item_view.hbs
@@ -13,6 +13,7 @@
         data-rv-class-count-success="job.lastRunSuccess"
         data-rv-class-count-error="job.lastRunError"
         data-rv-class-count-neutral="job.lastRunFresh"
+        data-rv-class-count-disabled="job.disabled"
         data-rv-data-title="job:toData | lastRunDescr"
         data-rv-text="job.lastRunStatus"
         data-container=".app"

--- a/src/main/resources/assets/app/scripts/views/job_item_view.js
+++ b/src/main/resources/assets/app/scripts/views/job_item_view.js
@@ -61,7 +61,11 @@ function($,
 
       this.$el.html(html);
       this.trigger('render', {sync: true});
+      if (this.model.get('disabled')) {
+        this.$el.addClass('disabled');
+      }
       this.setActive();
+
 
       return this;
     },


### PR DESCRIPTION
Users wanted a way to quickly see if jobs have been disabled. This adds some CSS styling and logic to the last-run-status UI element to show that. The text remains accurate (i.e. if the last run of the job was successful, but it's disabled now, the text says "success" but the oval is grey.

@hcai @brndnmtthws 
