### PR TITLE
[stats] Enable performance endpoint sorted by runtime.

### DIFF
--- a/src/main/resources/assets/app/scripts/bargraph.js
+++ b/src/main/resources/assets/app/scripts/bargraph.js
@@ -1,0 +1,171 @@
+function drawBarChart(chartID, data, selectString, nJobs) {
+  // chartID => A unique drawing identifier that has no spaces, no "." and no "#" characters.
+  // data => Input data for the chart, itself.
+  // selectString => String that allows you to pass in
+  //           a D3 select string.
+  // nJobs => The number of bars to render
+  // TODO: handle jobs that take zero time
+  var numJobs = Math.min(data.length, nJobs);
+  var dataSet = data.slice(0, numJobs+1);
+  var canvasWidth = $(selectString).parent().width();
+  var barsWidthTotal = canvasWidth / 1.5;
+  var barHeight = 20;
+  var barsHeightTotal = barHeight * numJobs;
+  var canvasHeight = numJobs * barHeight + 10; // +10 puts a little space at bottom.
+  var legendOffset = barHeight/2;
+  var legendBulletOffset = 30;
+  var legendTextOffset = 20;
+  var maxTime = d3.max(dataSet, function(d) {return d.time; });
+  var minTime = d3.min(dataSet, function(d) {return d.time; });
+  var x = d3.scale.log().domain([1, maxTime]).rangeRound([0, barsWidthTotal]);
+  var y = d3.scale.linear().domain([0, numJobs]).range([0, barsHeightTotal]);
+
+  // Color Scale Handling...
+  var colorScale = d3.scale.linear();
+  colorScale.domain([minTime, maxTime]);
+  colorScale.range(["seagreen", "red"]).interpolate(d3.interpolateHcl);
+
+  var synchronizedMouseOver = function() {
+    var bar = d3.select(this);
+    var indexValue = bar.attr("index_value");
+
+    var barSelector = "." + "bars-" + chartID + "-bar-" + indexValue;
+    var selectedBar = d3.selectAll(barSelector);
+    selectedBar.style("fill", "Maroon");
+
+    var textSelector = "." + "bars-" + chartID + "-legendText-" + indexValue;
+    var selectedLegendText = d3.selectAll(textSelector);
+    selectedLegendText.style("fill", "Maroon");
+  };
+
+  var synchronizedMouseOut = function() {
+    var bar = d3.select(this);
+    var indexValue = bar.attr("index_value");
+
+    var barSelector = "." + "bars-" + chartID + "-bar-" + indexValue;
+    var selectedBar = d3.selectAll(barSelector);
+    var colorValue = selectedBar.attr("color_value");
+    selectedBar.style("fill", colorValue);
+
+    var textSelector = "." + "bars-" + chartID + "-legendText-" + indexValue;
+    var selectedLegendText = d3.selectAll(textSelector);
+    selectedLegendText.style("fill", "Blue");
+  };
+
+  // Create the svg drawing canvas...
+  $(selectString).empty();
+  var canvas = d3.select(selectString)
+    .append("svg:svg")
+    .attr("width", canvasWidth)
+    .attr("height", canvasHeight);
+
+  // Draw individual hyper text enabled bars...
+  canvas.selectAll("rect")
+  .data(dataSet)
+  .enter().append("svg:a")
+    .append("svg:rect")
+      .attr("x", 0) // Right to left
+      .attr("y", function(d, i) { return y(i); })
+      .attr("height", barHeight)
+      .on('mouseover', synchronizedMouseOver)
+      .on("mouseout", synchronizedMouseOut)
+      .style("fill", "White" )
+      .style("stroke", "White" )
+      .transition()
+      .ease("bounce")
+        .duration(500)
+        .delay(function(d, i) { return i * 100; })
+      .attr("width", function(d) { return x(d.time); })
+      .style("fill", function(d, i) { colorVal = colorScale(d.time); return colorVal; } )
+      .attr("index_value", function(d, i) { return "index-" + i; })
+      .attr("class", function(d, i) { return "bars-" + chartID + "-bar-index-" + i; })
+      .attr("color_value", function(d, i) { return colorScale(d.time); }) // Bar fill color...
+      .style("stroke", "white"); // Bar border color...
+
+
+  // Create text values that go at end of each bar...
+  canvas.selectAll("text")
+  .data(dataSet) // Bind dataSet to text elements
+  .enter().append("svg:text") // Append text elements
+    .attr("x", x)
+    .attr("y", function(d, i) { return y(i); })
+    //.attr("y", function(d) { return y(d) + y.rangeBand() / 2; })
+    .attr("dx", function(d) { return x(d.time) - 5; })
+    .attr("dy", barHeight-5) // vertical-align: middle
+    .attr("text-anchor", "end") // text-align: right
+    .text(function(d) { return readableDuration(Math.round(d.time)*1000);})
+    .attr("fill", "White");
+
+  // Create hyper linked text at right that acts as label key...
+  canvas.selectAll("a.legend_link")
+  .data(dataSet) // Instruct to bind dataSet to text elements
+  .enter().append("svg:a") // Append legend elements
+    .attr("xlink:href", function(d) { return "/#jobs/" + d.jobNameLabel; })
+      .append("text")
+        .attr("text-anchor", "center")
+        .attr("x", barsWidthTotal + legendBulletOffset + legendTextOffset)
+        .attr("y", function(d, i) { return legendOffset + i*barHeight; } )
+        .attr("dx", 0)
+        .attr("dy", "5px") // Controls padding to place text above bars
+        .text(function(d) { return d.jobNameLabel;})
+        .style("fill", "Blue")
+        .attr("index_value", function(d, i) { return "index-" + i; })
+        .attr("class", function(d, i) { return "bars-" + chartID + "-legendText-index-" + i; })
+        .on('mouseover', synchronizedMouseOver)
+        .on("mouseout", synchronizedMouseOut);
+}
+var readableDuration = (function() {
+//From https://gist.github.com/betamos/6306412
+	// Each unit is an object with a suffix s and divisor d
+	var units = [
+		{s: 'ms', d: 1},
+		{s: 's', d: 1000},
+		{s: 'm', d: 60},
+		{s: 'h', d: 60},
+		{s: 'd', d: 24},
+		{s: 'y', d: 365} // final unit
+	];
+
+	// Closure function
+	return function(t) {
+		t = parseInt(t); // In order to use modulus
+		var trunc, n = Math.abs(t), i, out = []; // out: list of strings to concat
+		for (i = 0; i < units.length; i++) {
+			n = Math.floor(n / units[i].d); // Total number of this unit
+			// Truncate e.g. 26h to 2h using modulus with next unit divisor
+			trunc = (i+1 < units.length) ? n % units[i+1].d : n; // …if not final unit
+			trunc ? out.unshift(''+ trunc + units[i].s) : null; // Output if non-zero
+		}
+		(t < 0) ? out.unshift('-') : null; // Handle negative durations
+		return out.join(' ');
+	};
+})();
+
+
+$(function() {
+  $("#chart_mean").click( function() {
+    $.getJSON("/scheduler/stats/mean", function(result) {
+        drawBarChart("mean", result, "#barchart .chart", 10);
+    });
+  });
+  $("#chart_median").click( function() {
+    $.getJSON("/scheduler/stats/median", function(result) {
+        drawBarChart("median", result, "#barchart .chart", 10);
+    });
+  });
+  $("#chart_75").click( function() {
+    $.getJSON("/scheduler/stats/75thPercentile", function(result) {
+        drawBarChart("75", result, "#barchart .chart", 10);
+    });
+  });
+  $("#chart_95").click( function() {
+    $.getJSON("/scheduler/stats/95thPercentile", function(result) {
+        drawBarChart("95", result, "#barchart .chart", 10);
+    });
+  });
+  $("#chart_99").click( function() {
+    $.getJSON("/scheduler/stats/99thPercentile", function(result) {
+        drawBarChart("99", result, "#barchart .chart", 10);
+    });
+  });
+});

--- a/src/main/resources/assets/app/scripts/templates/main_menu.hbs
+++ b/src/main/resources/assets/app/scripts/templates/main_menu.hbs
@@ -23,10 +23,11 @@
   </li>
 </ul>
 
-<div>
+<div style="text-align:center">
   <button class="btn width clear-btn pull-right view-graph">
     <i class="icon-retweet"></i> Dependency Graph
   </button>
 
   <button class="btn width clear-btn pull-right new-job">✚ New Job</button>
+  <a href="stats.html" style="color:White">Jobs sorted by runtime statistics</a>
 </div>

--- a/src/main/resources/assets/app/scripts/views/main_menu.js
+++ b/src/main/resources/assets/app/scripts/views/main_menu.js
@@ -41,7 +41,6 @@ function($,
       e && e.preventDefault();
       return false;
     }
-
   });
 
   return MainMenu;

--- a/src/main/resources/assets/app/stats.html
+++ b/src/main/resources/assets/app/stats.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+    <title>Statistics</title>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.2.2/d3.v3.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+</head>
+<body>
+    <center>
+        <a id="chart_mean" href="mean">Mean</a>
+        <a id="chart_median" href="median">50th</a>
+        <a id="chart_75" href="75">75th</a>
+        <a id="chart_95" href="95">95th</a>
+        <a id="chart_99" href="99">99th</a>
+        <div id="barchart">
+            <div class="chart"></div>
+        </div>
+    </center>
+    <script src="scripts/barchart.js"></script>
+</body>
+</html>

--- a/src/main/scala/com/airbnb/scheduler/Main.scala
+++ b/src/main/scala/com/airbnb/scheduler/Main.scala
@@ -51,6 +51,7 @@ object Main extends ScalaService[SchedulerConfiguration] {
     environment.addResource(injector.getInstance(classOf[JobManagementResource]))
     environment.addResource(injector.getInstance(classOf[TaskManagementResource]))
     environment.addResource(injector.getInstance(classOf[GraphManagementResource]))
+    environment.addResource(injector.getInstance(classOf[StatsResource]))
 
     environment.manage(injector.getInstance(classOf[JobScheduler]))
     environment.manage(injector.getInstance(classOf[MetricReporterService]))

--- a/src/main/scala/com/airbnb/scheduler/api/PathConstants.scala
+++ b/src/main/scala/com/airbnb/scheduler/api/PathConstants.scala
@@ -11,6 +11,7 @@ object PathConstants {
   final val jobBasePath = "/"
   final val jobPatternPath = "job/{jobName}"
   final val allJobsPath = "jobs"
+  final val allStatsPath = "stats/{percentile}"
   final val jobStatsPatternPath = "job/stat/{jobName}"
   final val graphBasePath = "/graph"
   final val jobGraphDotPath = "dot"

--- a/src/main/scala/com/airbnb/scheduler/api/StatsResource.scala
+++ b/src/main/scala/com/airbnb/scheduler/api/StatsResource.scala
@@ -1,0 +1,68 @@
+package com.airbnb.scheduler.api
+
+import java.util.logging.{Level, Logger}
+import javax.ws.rs._
+import javax.ws.rs.core.{MediaType, Response}
+import javax.ws.rs.core.Response.Status
+import scala.Array
+
+import com.airbnb.scheduler.config.SchedulerConfiguration
+import scala.collection.mutable.ListBuffer
+import com.airbnb.scheduler.jobs._
+import com.airbnb.scheduler.graph.JobGraph
+import com.google.inject.Inject
+import com.yammer.metrics.annotation.Timed
+import com.fasterxml.jackson.databind.ObjectMapper
+import scala.collection.JavaConversions._
+/**
+ * The REST API to the PerformanceResource component of the API.
+ * @author Matt Redmond (matt.redmond@airbnb.com)
+ * Returns a list of jobs, sorted by percentile run times.
+ */
+
+@Path(PathConstants.allStatsPath)
+@Produces(Array(MediaType.APPLICATION_JSON))
+class StatsResource @Inject()(
+                                     val jobScheduler: JobScheduler,
+                                     val jobGraph: JobGraph,
+                                     val configuration: SchedulerConfiguration,
+                                     val jobMetrics: JobMetrics) {
+
+  private[this] val log = Logger.getLogger(getClass.getName)
+
+  @Timed
+  @GET
+  // Valid arguments are
+  // /scheduler/stats/99thPercentile
+  // /scheduler/stats/98thPercentile
+  // /scheduler/stats/95thPercentile
+  // /scheduler/stats/75thPercentile
+  // /scheduler/stats/median
+  // /scheduler/stats/mean
+  def getPerf(@PathParam("percentile") percentile: String): Response = {
+    try {
+      var output = ListBuffer[Map[String, Any]]()
+      var jobs = ListBuffer[(String, Double)]()
+
+      val mapper = new ObjectMapper()
+      for (jobNameString <- jobGraph.dag.vertexSet()) {
+        val node = mapper.readTree(jobMetrics.getJsonStats(jobNameString))
+        if (node.has(percentile) && node.get(percentile) != null) {
+          val time = node.get(percentile).asDouble()
+          jobs.append((jobNameString, time))
+        }
+      }
+      jobs = jobs.sortBy(_._2).reverse
+      for ( (jobNameString, time) <- jobs) {
+        val myMap = Map("jobNameLabel" -> jobNameString, "time" -> time / 1000.0)
+        output.append(myMap)
+      }
+      Response.ok(output).build
+    } catch {
+      case ex: Throwable => {
+        log.log(Level.WARNING, "Exception while serving request", ex)
+        throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Creates an endpoint to visualize the slowest chronos jobs.

Allows users to see the (sorted) list of slowest chronos jobs by various distribution parameters:

You can sort by mean, median, 75thPercentile, 95thPercentile, 98thPercentile, and 99thPercentile by hitting the endpoint at /scheduler/stats/{whatever}

Returns a JSON of the form [ {"jobNameLabel": jobname, "time": timeInSeconds}, {"jobNameLabel": jobname, "time": timeInSeconds}, ...]

Also provides a clickable bar chart for easier visualization - currently we render the top ten jobs.

@brndnmtthws @hcai @andykram @krisr 

![barchart](https://f.cloud.github.com/assets/525770/1084471/55100bc2-15af-11e3-98eb-18df7d68f8a7.gif)
