### PR TITLE
Updated the maven shade plugin version to 2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <maven-clean-plugin.version>2.5</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
         <maven-javadoc-plugin.version>2.9</maven-javadoc-plugin.version>
-        <maven-shade-plugin.version>2.0</maven-shade-plugin.version>
+        <maven-shade-plugin.version>2.1</maven-shade-plugin.version>
         <maven-surefire-plugins.version>2.14.1</maven-surefire-plugins.version>
         <scala-maven-plugin.version>3.1.0</scala-maven-plugin.version>
     </properties>


### PR DESCRIPTION
The maven shade plugin breaks the build with following error 

java.lang.NoClassDefFoundError: org/sonatype/aether/version/VersionConstraint
[WARNING] Error injecting: org.apache.maven.shared.dependency.graph.internal.Maven3DependencyGraphBuilder
The error details can be found at
https://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound

This error is caused by Maven 3.1-alpha-1 migration from Sonatype Aether to Eclipse Aether (MNG-5354), which is an incompatible change for some plugins.
The fix is to update plugin version to 2.1
