### PR TITLE
[assets] Update asset building

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,8 @@ from Chronos code but rather from some Scala classes, consider upgrading to Open
 
 ##### Build Chronos
 
+  # Install node
+  # OSX: brew install node
 	export MESOS_NATIVE_LIBRARY=/usr/local/lib/libmesos.so
 	git clone https://github.com/airbnb/chronos.git
 	cd chronos

--- a/build.xml
+++ b/build.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project name="chronos">
 
-  <!-- Inspired by: https://gist.github.com/millermedeiros/825117 -->
   <target name="-optimize" description="Combine and minify files.">
-    <java classname="org.mozilla.javascript.tools.shell.Main" failonerror="true">
-      <classpath path="${compile_classpath}" />
-      <arg value="${requirejs.optimizer.script}"/>
-      <arg value="-o"/>
-      <arg value="${requirejs.optimizer.settings}"/>
-    </java>
-    <echo message="optimized ${requirejs.optimizer.settings}" />
+    <exec executable="node">
+        <arg value="${requirejs.optimizer.script}"/>
+        <arg value="-o"/>
+        <arg value="${requirejs.optimizer.settings}"/>
+    </exec>
+    <echo message="optimized ${requirejs.optimizer.settings} with node" />
   </target>
 
   <target name="assets.uptodate" depends="sourceDir.check" if="sourceDir.nochanges">

--- a/docs/WEBUI.md
+++ b/docs/WEBUI.md
@@ -6,6 +6,8 @@
 
 ## Compiling Assets
 
+**Node.js is required to build assets**
+
 Assets are automatically compiled when running `mvn package`. If you change assets, and want them updated in your jar, you must either `rm -rf src/main/resources/assets/build` or `mvn clean`.
 
 ## Modifying Assets

--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,6 @@
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <twitter-commons.version>0.0.44</twitter-commons.version>
 
-        <!-- build deps versions -->
-        <closure-compiler.version>v20130411</closure-compiler.version>
-        <rhino.version>1.7R4</rhino.version>
-
         <!-- test deps versions -->
         <junit.version>4.11</junit.version>
         <mockito.version>1.9.5</mockito.version>
@@ -212,20 +208,6 @@
             <artifactId>maven-surefire-report-plugin</artifactId>
             <version>${maven-surefire-plugins.version}</version>
             <scope>test</scope>
-        </dependency>
-
-
-        <!-- Only needed at build time -->
-        <dependency>
-            <groupId>org.mozilla</groupId>
-            <artifactId>rhino</artifactId>
-            <version>${rhino.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.javascript</groupId>
-            <artifactId>closure-compiler</artifactId>
-            <version>${closure-compiler.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/assets/app.build.js
+++ b/src/main/resources/assets/app.build.js
@@ -12,7 +12,7 @@
       'lessc-server'
     ],
     findNestedDependencies: true,
-    optimize: "closure",
+    optimize: "uglify",
     closure: {
       CompilerOptions: {
       },


### PR DESCRIPTION
**NOTE**: This PR switches the asset packaging from rhino to node.js. Node is now required to build chronos. This should also dramatically decrease asset compilation times.

This should fix most issues with asset building.
