### PR TITLE
Consolidate font stylesheet requests

### DIFF
--- a/src/main/resources/assets/app/scripts/fonts.js
+++ b/src/main/resources/assets/app/scripts/fonts.js
@@ -1,7 +1,5 @@
 define([
-  'font!google,families:[Russo One]',
-  'font!google,families:[Quicksand]',
-  'font!google,families:[Inconsolata]'
+  'font!google,families:[Russo One,Quicksand,Inconsolata]'
 ],
 function() {
 


### PR DESCRIPTION
Each `'font!google'` dependency injects a new `<link>` element referring to
that font's stylesheet. The API supports multiple font-families in a
single request, which consolidates stylesheet requests.

This removes two HTTP requests to Google's font API.
