### PR TITLE
Fix bash scripts

### DIFF
--- a/bin/chronos-marathon
+++ b/bin/chronos-marathon
@@ -12,11 +12,11 @@ export PORT0="${PORT0:-4400}"
 flags=()
 
 #If we're on Amazon, let's use the public hostname so redirect works as expected.
-if public_hostname="$( curl -f --timeout 1 http://169.254.169.254/latest/meta-data/public-hostname )"
-else
-  flags+=( --hostname `hostname` )
+if public_hostname="$( curl -sSf --connect-timeout 1 http://169.254.169.254/latest/meta-data/public-hostname )"
 then
   flags+=( --hostname $public_hostname )
+else
+  flags+=( --hostname `hostname` )
 fi
 
 jar_files=( "$chronos_home"/target/chronos*.jar )

--- a/bin/start-chronos.bash
+++ b/bin/start-chronos.bash
@@ -1,28 +1,27 @@
 #!/bin/bash
-#
-# This is a sample script for starting chronos. If you deploy the service you may want to build custom
-# runit, monit or upstart scripts.
-CHRONOS_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+set -o errexit -o nounset -o pipefail
 
-echo $CHRONOS_HOME
+chronos_home="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd -P )"
+echo "Chronos home set to $chronos_home"
+export JAVA_LIBRARY_PATH="/usr/local/lib:/lib:/usr/lib"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-/lib}"
+export LD_LIBRARY_PATH="$JAVA_LIBRARY_PATH:$LD_LIBRARY_PATH"
 
-# This setup assumes you started with the mesos source and installed the binaries into
-# the ./build directory of the mesos source. Modify this as needed.
+flags=( "$@" )
 
-# TODO(FL): ensure this script runs on *nix as well.
-# TODO(FL): clean-up!
-echo "This script is setup to run on MacOSX right now. Modify it to run on other systems."
-default_mesos_home=/usr/local/mesos
-MESOS_HOME=${1:-$default_mesos_home}
-echo "MESOS_HOME is set to: $MESOS_HOME"
-pushd $MESOS_HOME
-libmesos_file=$(find . -name "libmesos.dylib" | head -n1)
-build_env=$(find . -name "mesos-build-env.sh" | head -n1)
-export MESOS_NATIVE_LIBRARY="${MESOS_HOME}/${libmesos_file}"
-echo "MESOS_NATIVE_LIBRARY set to $MESOS_NATIVE_LIBRARY"
-echo "Sourcing mesos-build-env.sh: $build_env"
-source $build_env
-popd
+#If we're on Amazon, let's use the public hostname so redirect works as expected.
+if public_hostname="$( curl -sSf --connect-timeout 1 http://169.254.169.254/latest/meta-data/public-hostname )"
+then
+  flags+=( --hostname $public_hostname )
+else
+  flags+=( --hostname `hostname` )
+fi
 
-# Start chronos.
-java -cp "$CHRONOS_HOME"/target/chronos*.jar com.airbnb.scheduler.Main $@
+jar_files=( "$chronos_home"/target/chronos*.jar )
+echo "Using jar file: $jar_files[0]"
+
+heap=384m
+
+java -Xmx"$heap" -Xms"$heap" -cp "${jar_files[0]}" \
+     com.airbnb.scheduler.Main \
+     "${flags[@]}"


### PR DESCRIPTION
start-chronos.bash was using outdated options and looking for the Mesos lib in the wrong place. Also fix some syntax errors.
