### PR TITLE
[application_view] update jobs count on init

### DIFF
--- a/src/main/resources/assets/app/scripts/views/application_view.js
+++ b/src/main/resources/assets/app/scripts/views/application_view.js
@@ -31,6 +31,7 @@ function($,
         reset: this.updateJobsCount,
         sync: this.setPersisted
       });
+      this.updateJobsCount();
     },
 
     setPersisted: function(collection, resp, options) {


### PR DESCRIPTION
Turns out the total jobs count wasn't being updated when the app is first loaded.

/cc @ssorallen
