### PR TITLE
Fix resource bug in MesosJobFramework.buildTask()

### DIFF
--- a/src/main/scala/com/airbnb/scheduler/mesos/MesosJobFramework.scala
+++ b/src/main/scala/com/airbnb/scheduler/mesos/MesosJobFramework.scala
@@ -163,13 +163,13 @@ class MesosJobFramework @Inject()(
         log.info(x.getScalar.getValue.getClass.getName)
         x.getType match {
           case Value.Type.SCALAR =>
-            x.getName match {
+            val needed = x.getName match {
               case "mem" =>
-                if (job.mem == 0) config.mesosTaskMem else job.mem
+                if (job.mem == 0) config.mesosTaskMem() else job.mem
               case "cpus" =>
-                if (job.cpus == 0) config.mesosTaskCpu else job.cpus
+                if (job.cpus == 0) config.mesosTaskCpu() else job.cpus
               case "disk" =>
-                if (job.disk == 0) config.mesosTaskDisk else job.disk
+                if (job.disk == 0) config.mesosTaskDisk() else job.disk
               case _ =>
                 x.getScalar.getValue / math.max(x.getScalar.getValue, 1)
             }
@@ -177,7 +177,7 @@ class MesosJobFramework @Inject()(
             x.getScalar.getValue match {
 
               case value: Double => {
-                if (value.doubleValue() <= x.getScalar.getValue && !sufficient(x.getName)) {
+                if (needed <= value && !sufficient(x.getName)) {
                   sufficient(x.getName) = true
                 }
               }


### PR DESCRIPTION
It seems like task creation doesn't actually respect resource limits given by mesos.

In tests with mesos-0.14.0-rc4, I've seen mesos simply drop tasks that don't fit within offered resource constraints.

I don't recall seeing this behavior in early versions of mesos... 
