### PR TITLE
Add debian upstart script.

### DIFF
--- a/bin/chronos.debian.upstart
+++ b/bin/chronos.debian.upstart
@@ -1,0 +1,38 @@
+# chronos.conf
+
+description "Chronos scheduler for Mesos"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+respawn limit 10 5
+
+setuid chronos
+
+# Note that you can add this line to your rsyslog conf
+# to get a /var/log/chronos.log
+# :programname, isequal, "chronos"                       /var/log/chronos.log
+
+# Custom local
+script
+  [ ! -f /etc/default/chronos ]    || . /etc/default/chronos
+  set -e
+  mkfifo /tmp/chronos-log-stdout-fifo
+  mkfifo /tmp/chronos-log-stderr-fifo
+  ( logger -p user.info -t chronos </tmp/chronos-log-stdout-fifo & )
+  ( logger -p user.err  -t chronos </tmp/chronos-log-stderr-fifo & )
+  exec 1>/tmp/chronos-log-stdout-fifo
+  exec 2>/tmp/chronos-log-stderr-fifo
+  rm /tmp/chronos-log-stdout-fifo
+  rm /tmp/chronos-log-stderr-fifo
+  exec java \
+    ${MEM_OPTS:+$MEM_OPTS} \
+    ${LIB_PATH:+-Djava.library.path=$LIB_PATH} \
+    ${CHRONOS_JAR:+-cp $CHRONOS_JAR com.airbnb.scheduler.Main} \
+    ${ZK_HOSTS:+--zk_hosts "$ZK_HOSTS"} \
+    ${MASTER:+--master $MASTER} \
+    ${HTTP_PORT:+--http_port $HTTP_PORT} \
+    ${HTTPS_PORT:+--https_port $HTTPS_PORT} \
+    ${OPTS:+$OPTS}
+end script


### PR DESCRIPTION
For those that want to use an upstart-based init I've created on that I'm using locally. Note that there is an assumption that the user is "chronos".  I can't take credit for the logger stuff, as that was jacked from both the mesos-init-wrapper and [this answer on StackOverflow](http://serverfault.com/questions/114052/logging-a-daemons-output-with-upstart).
