### PR TITLE
Fix a bug in determining whether a task is async

### DIFF
--- a/src/main/scala/com/airbnb/scheduler/jobs/JobScheduler.scala
+++ b/src/main/scala/com/airbnb/scheduler/jobs/JobScheduler.scala
@@ -84,7 +84,7 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
   }
 
   def isTaskAsync(taskId: String): Boolean = {
-    val TaskUtils.taskIdPattern(jobName, _, _) = taskId
+    val TaskUtils.taskIdPattern(_, _, jobName) = taskId
     jobGraph.lookupVertex(jobName) match {
       case Some(baseJob: BaseJob) => baseJob.async
       case _ => false


### PR DESCRIPTION
This bug was causing async jobs to automatically succeed when the driver script finished. The pattern was grabbing the first component of the task id, which is a timestamp, not the job name.
