### PR TITLE
add support for ganglia host spoofing

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -25,10 +25,12 @@ To get a full list of options, use start-chronos.bash --help:
       -g, --ganglia_host_port  <arg>            Host and port for Ganglia
           --ganglia_reporting_interval  <arg>   Ganglia reporting interval (seconds)
                                                 (default = 60)
+          --ganglia_spoof  <arg>                IP:host to spoof for Ganglia
+                                                (default = actual hostname)
       -h, --hostname  <arg>                     The advertised hostname stored in
                                                 ZooKeeper so another standby host can
                                                 redirect to this elected leader
-                                                (default = Macintosh.local)
+                                                (default = actual hostname)
           --http_credentials  <arg>             Credentials for accessing the http
                                                 service.If empty, anyone can access
                                                 the HTTP endpoint. A

--- a/src/main/resources/assets/app/index.html
+++ b/src/main/resources/assets/app/index.html
@@ -58,9 +58,6 @@
               <button class="btn clear-btn view-graph">
                 <i class="icon-retweet"></i> Graph
               </button>
-              <a class="btn clear-btn" href="stats.html">
-                Statistics
-              </a>
               <button class="btn clear-btn new-job">✚ New Job</button>
             </div>
           </div>

--- a/src/main/scala/com/airbnb/scheduler/config/GangliaConfiguration.scala
+++ b/src/main/scala/com/airbnb/scheduler/config/GangliaConfiguration.scala
@@ -17,4 +17,8 @@ trait GangliaConfiguration extends ScallopConf {
   lazy val gangliaGroupPrefix = opt[String]("ganglia_group_prefix",
     descr = "Group prefix for Ganglia",
     default = Some(""))
+
+  lazy val gangliaSpoofHost = opt[String]("ganglia_spoof",
+    descr = "IP:host to spoof for Ganglia",
+    default = None)
 }

--- a/src/main/scala/com/airbnb/scheduler/jobs/MetricReporterService.scala
+++ b/src/main/scala/com/airbnb/scheduler/jobs/MetricReporterService.scala
@@ -27,7 +27,11 @@ class MetricReporterService(config: GangliaConfiguration,
   def startUp() {
     this.reporter = config.gangliaHostPort.get match {
       case Some(MetricReporterService.HostPort(host: String, port: Int)) => {
-        val ganglia = new GMetric(host, port, UDPAddressingMode.MULTICAST, 1)
+        val ganglia = config.gangliaSpoofHost.get match {
+          case Some(spoof: String) => new GMetric(host, port,
+            UDPAddressingMode.MULTICAST, 1, true, null, spoof)
+          case _ => new GMetric(host, port, UDPAddressingMode.MULTICAST, 1)
+        }
         val reporter = GangliaReporter.forRegistry(registry)
           .prefixedWith(config.gangliaGroupPrefix())
           .convertRatesTo(TimeUnit.SECONDS)


### PR DESCRIPTION
Adds a --ganglia_spoof config option allowing the hostname ganglia stats are sent from to be changed.  (Also removes the stats.html button since that page has been broken for a while.)
