### PR TITLE
[Reservations] Use reserved resources with higher priority.

### DIFF
--- a/src/main/scala/com/airbnb/scheduler/mesos/MesosJobFramework.scala
+++ b/src/main/scala/com/airbnb/scheduler/mesos/MesosJobFramework.scala
@@ -201,7 +201,7 @@ class MesosJobFramework @Inject()(
 
     val filters: Filters = Filters.newBuilder().setRefuseSeconds(0.1).build()
 
-    log.info("Launching task with offer: " + mesosTask)
+    log.info("Launching task from offer: " + offer + " with task: " + mesosTask)
 
     import scala.collection.JavaConverters._
     if (runningJobs.contains(job.name)) {


### PR DESCRIPTION
Tested by looking at the logs and ensuring that the offers used were prioritizing reserved resources where available.

Here's one instance:

```
INFO: Launching task from offer: id {
  value: "201403300323-2276627466-5050-22850-274774"
}
framework_id {
  value: "201311221905-200446986-5050-25877-0000"
}
slave_id {
  value: "201403300153-200446986-5050-30626-7"
}
hostname: "i-dcc171f2"
resources {
  name: "mem"
  type: SCALAR
  scalar {
    value: 658.0
  }
  role: "*"
}
resources {
  name: "disk"
  type: SCALAR
  scalar {
    value: 703917.05
  }
  role: "*"
}
resources {
  name: "ports"
  type: RANGES
  ranges {
    range {
      begin: 31599
      end: 32000
    }
    range {
      begin: 31000
      end: 31227
    }
    range {
      begin: 31229
      end: 31563
    }
    range {
      begin: 31565
      end: 31597
    }
  }
  role: "*"
}
resources {
  name: "cpus"
  type: SCALAR
  scalar {
    value: 2.0
  }
  role: "*"
}
resources {
  name: "cpus"
  type: SCALAR
  scalar {
    value: 3.0
  }
  role: "chronos"
}
resources {
  name: "mem"
  type: SCALAR
  scalar {
    value: 3072.0
  }
  role: "chronos"
}
attributes {
  name: "rackid"
  type: TEXT
  text {
    value: "us-east-1a"
  }
}
slave_load_hint: 1.78
 with task: name: "ChronosTask:hadoop_benchmark2"
task_id {
  value: "ct:1396379661250:0:hadoop_benchmark2"
}
slave_id {
  value: "201403300153-200446986-5050-30626-7"
}
resources {
  name: "cpus"
  type: SCALAR
  scalar {
    value: 1.0
  }
  role: "chronos"
}
resources {
  name: "mem"
  type: SCALAR
  scalar {
    value: 1024.0
  }
  role: "chronos"
}
resources {
  name: "disk"
  type: SCALAR
  scalar {
    value: 10240.0
  }
  role: "*"
}
```

@brndnmtthws 
