### PR TITLE
Fix for dependency invocation handling.

### DIFF
--- a/src/main/scala/com/airbnb/scheduler/graph/JobGraph.scala
+++ b/src/main/scala/com/airbnb/scheduler/graph/JobGraph.scala
@@ -163,6 +163,16 @@ class JobGraph {
     results.toList
   }
 
+  def resetDependencyInvocations(vertex: String) {
+    val edges = getEdgesToParents(vertex)
+    lock.synchronized {
+      edges.foreach({
+        edge =>
+          edgeInvocationCount.put(edge, 0)
+      })
+    }
+  }
+
   def getChildren(job: String): Iterable[String] = {
     import collection.JavaConversions._
     lock.synchronized {

--- a/src/main/scala/com/airbnb/scheduler/jobs/JobScheduler.scala
+++ b/src/main/scala/com/airbnb/scheduler/jobs/JobScheduler.scala
@@ -252,6 +252,12 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
       val job = jobOption.get
       val (_, _, attempt) = TaskUtils.parseTaskId(taskId)
       jobStats.jobStarted(job, taskStatus, attempt)
+
+      job match {
+        case j: DependencyBasedJob =>
+          jobGraph.resetDependencyInvocations(j.name)
+        case _ =>
+      }
     }
   }
 
@@ -359,6 +365,7 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
       jobOption match {
         case Some(job) => {
           jobStats.jobFailed(job, taskStatus, attempt)
+
           val hasAttemptsLeft: Boolean = attempt < job.retries
 
           val hadRecentSuccess: Boolean = job.lastError.length > 0 && job.lastSuccess.length > 0 &&

--- a/src/main/scala/com/airbnb/scheduler/jobs/JobUtils.scala
+++ b/src/main/scala/com/airbnb/scheduler/jobs/JobUtils.scala
@@ -95,8 +95,6 @@ object JobUtils {
               //Setup all the dependencies
               y: BaseJob =>
                 scheduler.jobGraph.addDependency(y.name, x.name)
-                scheduler.jobGraph.dag.getAllEdges(y.name, x.name)
-                  .foreach(e => scheduler.jobGraph.edgeInvocationCount.put(e, y.successCount))
             }
         }
     }


### PR DESCRIPTION
This fixes 2 things:
- don't try to restore invocation counts from ZK state (as they may be
  wrong due to missed status updates).
- reset the invocation counts any time a dependent job starts.

@airbnb/di 
