### PR TITLE
Fix http port 80 issue.

### DIFF
--- a/bin/chronos-sync.rb
+++ b/bin/chronos-sync.rb
@@ -292,7 +292,7 @@ jobs_to_be_updated.each do |j|
   puts "Sending PUT for `#{job['name']}` to #{uri.request_uri}"
 
   begin
-    res = Net::HTTP.start(uri.hostname, port: uri.port, use_ssl: (uri.port == 443)) do |http|
+    res = Net::HTTP.start(uri.hostname, uri.port, :use_ssl => uri.scheme == 'https') do |http|
       http.request(req)
     end
 


### PR DESCRIPTION
chronos-sync.rb always uses port 80 for http URLs even if another port is specified in the url. 
