### PR TITLE
Fetch maven central artifacts over https. It is a security risk to fetch artifacts over http

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <pluginRepository>
       <id>repo1</id>
       <name>Maven Central</name>
-      <url>http://repo1.maven.org/maven2</url>
+      <url>https://repo1.maven.org/maven2</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>


### PR DESCRIPTION
For a description of the risks see http://blog.ontoillogical.com/blog/2014/07/28/how-to-take-over-any-java-developer/
