### PR TITLE
Add chronos job name to env vars

### DIFF
--- a/src/main/scala/com/airbnb/scheduler/mesos/MesosTaskBuilder.scala
+++ b/src/main/scala/com/airbnb/scheduler/mesos/MesosTaskBuilder.scala
@@ -85,6 +85,8 @@ class MesosTaskBuilder @Inject()(val conf: SchedulerConfiguration) {
         .setName("mesos_task_id").setValue(taskIdStr))
       .addVariables(Variable.newBuilder()
         .setName("CHRONOS_JOB_OWNER").setValue(job.owner))
+      .addVariables(Variable.newBuilder()
+        .setName("CHRONOS_JOB_NAME").setValue(job.name))
     if (job.executor.nonEmpty) {
       appendExecutorData(taskInfo, job)
     } else {


### PR DESCRIPTION
As per title. This would be useful if the launched process needs the job name for logging.
