### PR TITLE
Adding support for Mesos shell and arguments parameters to CommandInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,8 @@ you can also use a url in the command field, if your mesos was compiled with cUR
 | ------------------- |----------------------------------------------------------------------------------------------------------| -------------------------------|
 | name                | Name of job.                                                                                             | -                              |
 | command             | Command to execute.                                                                                      | -                              |
+| arguments           | Arguments to pass to the command.  Ignored if `shell` is true                                            | -                              |
+| shell               | If true, Mesos will execute `command` by running `/bin/sh -c <command>` and ignore `arguments`. If false, `command` will be treated as the filename of an executable and `arguments` will be the arguments passed.  If this is a Docker job and `shell` is true, the entrypoint of the container will be overridden with `/bin/sh -c`                                                                                      | true                              |
 | epsilon             | If, for any reason, a job can't be started at the scheduled time, this is the window in which Chronos will attempt to run the job again | `PT60S` or `--task_epsilon`. |
 | executor            | Mesos executor.  By default Chronos uses the Mesos command executor.                                     | -                              |
 | executorFlags       | Flags to pass to Mesos executor.                                                                         | -                              |
@@ -369,7 +371,7 @@ you can also use a url in the command field, if your mesos was compiled with cUR
 | disabled            | If set to true, this job will not be run.                                                                | `false`                        |
 | uris                | An array of URIs which Mesos will download when the task is started.                                     | -                              |
 | schedule            | ISO8601 repeating schedule for this job.  If specified, `parents` must not be specified.                 | -                              |
-| scheduleTimeZone    | The time zone for the given schedule.									 | -                              |
+| scheduleTimeZone    | The time zone for the given schedule.									 							     | -                              |
 | parents             | An array of parent jobs for a dependent job.  If specified, `schedule` must not be specified.            | -                              |
 | runAsUser           | Mesos will run the job as this user, if specified.                                                       | `--user`                       |
 | container           | This contains the subfields for the container, type (req), image (req), network (optional) and volumes (optional).          | -                              |
@@ -381,6 +383,11 @@ you can also use a url in the command field, if your mesos was compiled with cUR
 {
    "name":"camus_kafka2hdfs",
    "command":"/srv/data-infra/kafka/camus/kafka_hdfs_job.bash",
+   "arguments": [
+   	  "-verbose",
+   	  "-debug"
+   ]
+   "shell":"false",
    "epsilon":"PT30M",
    "executor":"",
    "executorFlags":"",

--- a/src/main/scala/com/airbnb/scheduler/jobs/Jobs.scala
+++ b/src/main/scala/com/airbnb/scheduler/jobs/Jobs.scala
@@ -44,6 +44,8 @@ trait BaseJob {
   def runAsUser: String = ""
   def container: DockerContainer = null
   def environmentVariables: Seq[EnvironmentVariable] = List()
+  def shell: Boolean = true
+  def arguments: Seq[String] = List()
 }
 
 @JsonDeserialize(using = classOf[JobDeserializer])
@@ -71,7 +73,9 @@ case class ScheduleBasedJob(
     @JsonProperty override val runAsUser: String = "",
     @JsonProperty override val container: DockerContainer = null,
     @JsonProperty scheduleTimeZone : String = "",
-    @JsonProperty override val environmentVariables: Seq[EnvironmentVariable] = List())
+    @JsonProperty override val environmentVariables: Seq[EnvironmentVariable] = List(),
+    @JsonProperty override val shell: Boolean = true,
+    @JsonProperty override val arguments: Seq[String] = List())
   extends BaseJob
 
 
@@ -99,5 +103,7 @@ case class DependencyBasedJob(
     @JsonProperty override val highPriority: Boolean = false,
     @JsonProperty override val runAsUser: String = "",
     @JsonProperty override val container: DockerContainer = null,
-    @JsonProperty override val environmentVariables: Seq[EnvironmentVariable] = List())
+    @JsonProperty override val environmentVariables: Seq[EnvironmentVariable] = List(),
+    @JsonProperty override val shell: Boolean = true,
+    @JsonProperty override val arguments: Seq[String] = List())
   extends BaseJob

--- a/src/main/scala/com/airbnb/scheduler/mesos/MesosTaskBuilder.scala
+++ b/src/main/scala/com/airbnb/scheduler/mesos/MesosTaskBuilder.scala
@@ -118,7 +118,9 @@ class MesosTaskBuilder @Inject()(val conf: SchedulerConfiguration) {
             .build()
         })
         command.setValue(job.command)
+          .setShell(job.shell)
           .setEnvironment(environment)
+          .addAllArguments(job.arguments.asJava)
           .addAllUris(uriProtos.asJava)
       }
       if (job.runAsUser.nonEmpty) {

--- a/src/main/scala/com/airbnb/utils/JobSerializer.scala
+++ b/src/main/scala/com/airbnb/utils/JobSerializer.scala
@@ -17,6 +17,9 @@ class JobSerializer extends JsonSerializer[BaseJob] {
 
     json.writeFieldName("command")
     json.writeString(baseJob.command)
+    
+    json.writeFieldName("shell")
+    json.writeBoolean(baseJob.shell)
 
     json.writeFieldName("epsilon")
     json.writeString(baseJob.epsilon.toString)
@@ -78,6 +81,11 @@ class JobSerializer extends JsonSerializer[BaseJob] {
     	json.writeString(v.value)
     	json.writeEndObject()
     }
+    json.writeEndArray()
+    
+    json.writeFieldName("arguments")
+    json.writeStartArray()
+    baseJob.arguments.foreach(json.writeString(_))
     json.writeEndArray()
     
     json.writeFieldName("highPriority")

--- a/src/test/scala/com/airbnb/scheduler/api/SerDeTest.scala
+++ b/src/test/scala/com/airbnb/scheduler/api/SerDeTest.scala
@@ -34,11 +34,16 @@ class SerDeTest extends SpecificationWithJUnit {
         Volume(Option("/host/dir"), "container/dir", Option(VolumeMode.RO)),
         Volume(None, "container/dir", None)
       )
+
       val container = DockerContainer("dockerImage", volumes, NetworkMode.BRIDGE)
 
+      val arguments = Seq(
+          "-testOne"
+      )
+      
       val a = new DependencyBasedJob(Set("B", "C", "D", "E"), "A", "noop", Minutes.minutes(5).toPeriod, 10L,
         20L, "fooexec", "fooflags", 7, "foo@bar.com", "TODAY", "YESTERDAY", true, container = container,
-        environmentVariables = environmentVariables)
+        environmentVariables = environmentVariables, shell = false, arguments = arguments)
 
       val aStr = objectMapper.writeValueAsString(a)
       val aCopy = objectMapper.readValue(aStr, classOf[DependencyBasedJob])
@@ -62,11 +67,16 @@ class SerDeTest extends SpecificationWithJUnit {
         Volume(Option("/host/dir"), "container/dir", Option(VolumeMode.RW)),
         Volume(None, "container/dir", None)
       )
-      val container = DockerContainer("dockerImage", volumes, NetworkMode.HOST)
 
+      val container = DockerContainer("dockerImage", volumes, NetworkMode.HOST)
+      
+      val arguments = Seq(
+          "-testOne"
+      )
+      
       val a = new ScheduleBasedJob("FOO/BAR/BAM", "A", "noop", Minutes.minutes(5).toPeriod, 10L, 20L,
         "fooexec", "fooflags", 7, "foo@bar.com", "TODAY", "YESTERDAY", true, container = container,
-        environmentVariables = environmentVariables)
+        environmentVariables = environmentVariables, shell = true, arguments = arguments)
 
       val aStr = objectMapper.writeValueAsString(a)
       val aCopy = objectMapper.readValue(aStr, classOf[ScheduleBasedJob])


### PR DESCRIPTION
As per http://mesos.apache.org/documentation/latest/upgrades/, Mesos now supports two modes of command execution - shell or non-shell.  For Docker containers, shell mode means that the Docker container's ENTRYPOINT gets overridden (see https://issues.apache.org/jira/browse/MESOS-1770).  In order to be able to use the standard ENTRYPOINT but override the CMD, we needed to be able to set shell=false on the Mesos task.  
