### PR TITLE
Adding brigde mode support for docker containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Here is a more elaborate example for a dependency job hash:
 ###Adding a Docker Job
 
 A docker job takes the same format as a scheduled job or a dependency job and runs on a docker container.
-To configure it, an additional container argument is required, which contains a type (req), an image (req), and volumes (optional). 
+To configure it, an additional container argument is required, which contains a type (req), an image (req), a network mode (optional) and volumes (optional). 
 
 * Endpoint: __/scheduler/iso8601__ or __/scheduler/dependency__
 * Method: __POST__
@@ -297,10 +297,11 @@ To configure it, an additional container argument is required, which contains a 
 {
  "schedule": "R\/2014-09-25T17:22:00Z\/PT2M",
  "name": "dockerjob",
-   "container": {
-   "type": "DOCKER",
-   "image": "libmesos/ubuntu"
-  },
+ "container": {
+  "type": "DOCKER",
+  "image": "libmesos/ubuntu",
+  "network": "BRIDGE"
+ },
  "cpus": "0.5",
  "mem": "512",
  "uris": [],
@@ -371,7 +372,7 @@ you can also use a url in the command field, if your mesos was compiled with cUR
 | scheduleTimeZone    | The time zone for the given schedule.									 | -                              |
 | parents             | An array of parent jobs for a dependent job.  If specified, `schedule` must not be specified.            | -                              |
 | runAsUser           | Mesos will run the job as this user, if specified.                                                       | `--user`                       |
-| container           | This contains the subfields for the container, type (req), image (req), and volumes (optional).          | -                              |
+| container           | This contains the subfields for the container, type (req), image (req), network (optional) and volumes (optional).          | -                              |
 | environmentVariables| An array of environment variables passed to the Mesos executor. For Docker containers, these are also passed to Docker using the -e flag. | -                              |
 
 ### Sample Job

--- a/src/main/scala/com/airbnb/scheduler/jobs/Containers.scala
+++ b/src/main/scala/com/airbnb/scheduler/jobs/Containers.scala
@@ -9,7 +9,15 @@ object VolumeMode extends Enumeration {
   val RW, RO = Value
 }
 
+object NetworkMode extends Enumeration {
+  type NetworkMode = Value
+
+  // Bridged and Host
+  val BRIDGE, HOST = Value
+}
+
 import VolumeMode._
+import NetworkMode._
 case class Volume(
   @JsonProperty hostPath: Option[String],
   @JsonProperty containerPath: String,
@@ -17,4 +25,5 @@ case class Volume(
 
 case class DockerContainer(
   @JsonProperty image: String,
-  @JsonProperty volumes: Seq[Volume])
+  @JsonProperty volumes: Seq[Volume],
+  @JsonProperty network: NetworkMode = NetworkMode.HOST)

--- a/src/main/scala/com/airbnb/scheduler/mesos/MesosTaskBuilder.scala
+++ b/src/main/scala/com/airbnb/scheduler/mesos/MesosTaskBuilder.scala
@@ -156,7 +156,10 @@ class MesosTaskBuilder @Inject()(val conf: SchedulerConfiguration) {
       volumeBuilder.build()
     }.foreach(builder.addVolumes)
     builder.setType(ContainerInfo.Type.DOCKER)
-    builder.setDocker(DockerInfo.newBuilder().setImage(job.container.image).build()).build
+    builder.setDocker(DockerInfo.newBuilder()
+      .setImage(job.container.image)
+      .setNetwork(DockerInfo.Network.valueOf(job.container.network.toString.toUpperCase))
+      .build()).build
   }
 
   def getExecutorName(x: String) = "%s".format(x)

--- a/src/main/scala/com/airbnb/utils/JobSerializer.scala
+++ b/src/main/scala/com/airbnb/utils/JobSerializer.scala
@@ -94,6 +94,8 @@ class JobSerializer extends JsonSerializer[BaseJob] {
       json.writeString("docker")
       json.writeFieldName("image")
       json.writeString(baseJob.container.image)
+      json.writeFieldName("network")
+      json.writeString(baseJob.container.network.toString)
       json.writeFieldName("volumes")
       json.writeStartArray()
       baseJob.container.volumes.foreach { v =>

--- a/src/test/scala/com/airbnb/scheduler/api/SerDeTest.scala
+++ b/src/test/scala/com/airbnb/scheduler/api/SerDeTest.scala
@@ -34,7 +34,7 @@ class SerDeTest extends SpecificationWithJUnit {
         Volume(Option("/host/dir"), "container/dir", Option(VolumeMode.RO)),
         Volume(None, "container/dir", None)
       )
-      val container = DockerContainer("dockerImage", volumes)
+      val container = DockerContainer("dockerImage", volumes, NetworkMode.BRIDGE)
 
       val a = new DependencyBasedJob(Set("B", "C", "D", "E"), "A", "noop", Minutes.minutes(5).toPeriod, 10L,
         20L, "fooexec", "fooflags", 7, "foo@bar.com", "TODAY", "YESTERDAY", true, container = container,
@@ -62,7 +62,7 @@ class SerDeTest extends SpecificationWithJUnit {
         Volume(Option("/host/dir"), "container/dir", Option(VolumeMode.RW)),
         Volume(None, "container/dir", None)
       )
-      val container = DockerContainer("dockerImage", volumes)
+      val container = DockerContainer("dockerImage", volumes, NetworkMode.HOST)
 
       val a = new ScheduleBasedJob("FOO/BAR/BAM", "A", "noop", Minutes.minutes(5).toPeriod, 10L, 20L,
         "fooexec", "fooflags", 7, "foo@bar.com", "TODAY", "YESTERDAY", true, container = container,


### PR DESCRIPTION
Mesos 0.20.1 added support for bridge mode networking in docker containers.  This PR allows Chronos jobs to specify the mode for containers it launches.  It defaults to HOST mode, which was the only option previously.  
