### PR TITLE
Clear job graph when no longer leader.

### DIFF
--- a/src/main/scala/com/airbnb/scheduler/jobs/JobScheduler.scala
+++ b/src/main/scala/com/airbnb/scheduler/jobs/JobScheduler.scala
@@ -666,6 +666,7 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
 
     log.info("Defeated. Not the current leader.")
     running.set(false)
+    jobGraph.reset() // So we can rebuild it later.
     schedulerThreadFuture.get.cancel(true)
   }
 


### PR DESCRIPTION
When re-elected, Chronos attempts to re-create the job graph; this
patch prevents doing so with vertexes that are already in the job
graph, which is an illegal operation. (For Issue #290)
