### PR TITLE
Remove a meaningless function invoking

### DIFF
--- a/src/main/scala/com/airbnb/scheduler/jobs/JobUtils.scala
+++ b/src/main/scala/com/airbnb/scheduler/jobs/JobUtils.scala
@@ -109,7 +109,7 @@ object JobUtils {
           Some(new ScheduleStream(job.schedule, job.name))
         }
       case None =>
-        skipForward(job, dateTime)
+        None
     }
   }
 


### PR DESCRIPTION
Invoking skipForwad is not needed if job.schedule cannot be parsed.
So it is meaningless to parse it twice.
