### PR TITLE
Fix: task isn't removed from zk when failure hanppens

### DIFF
--- a/src/main/scala/com/airbnb/scheduler/jobs/JobScheduler.scala
+++ b/src/main/scala/com/airbnb/scheduler/jobs/JobScheduler.scala
@@ -389,7 +389,7 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
             /* Schedule the retry up to 60 seconds in the future */
             val newTaskId = TaskUtils.getTaskId(job, DateTime.now(DateTimeZone.UTC)
               .plus(new Duration(failureRetryDelay)), attempt + 1)
-            taskManager.persistTask(taskId, job)
+            taskManager.persistTask(newTaskId, job)
             taskManager.enqueue(newTaskId, job.highPriority)
           } else {
             val disableJob =


### PR DESCRIPTION
Persisting the old taskId but not the new one when handling failed task
causes the problem.
