### PR TITLE
Change http code from 200 to 500 when proxying error

### DIFF
--- a/src/main/scala/com/airbnb/scheduler/api/RedirectFilter.scala
+++ b/src/main/scala/com/airbnb/scheduler/api/RedirectFilter.scala
@@ -102,7 +102,9 @@ class RedirectFilter @Inject()(val jobScheduler: JobScheduler) extends Filter  {
           proxy.getInputStream.close
           responseOutputStream.close
         } catch {
-          case t: Exception => log.log(Level.WARNING, "Exception while proxying!", t)
+          case t: Exception => 
+            response.sendError(500)
+            log.log(Level.WARNING, "Exception while proxying!", t)
         }
       }
     }


### PR DESCRIPTION
Proxying request will throw exception but return 200 if the current
leader crashes, which may affect the judgement of user whether the job
is successful or not. Changing it to 500 to avoid this question.
