### PR TITLE
Add some useful environment variables to the Chronos task

### DIFF
--- a/src/main/scala/com/airbnb/scheduler/mesos/MesosTaskBuilder.scala
+++ b/src/main/scala/com/airbnb/scheduler/mesos/MesosTaskBuilder.scala
@@ -89,7 +89,13 @@ class MesosTaskBuilder @Inject()(val conf: SchedulerConfiguration) {
         .setName("CHRONOS_JOB_NAME").setValue(job.name))
       .addVariables(Variable.newBuilder()
         .setName("HOST").setValue(offer.getHostname))
-        
+      .addVariables(Variable.newBuilder()
+        .setName("CHRONOS_RESOURCE_MEM").setValue(job.mem.toString))
+      .addVariables(Variable.newBuilder()
+        .setName("CHRONOS_RESOURCE_CPU").setValue(job.cpus.toString))
+      .addVariables(Variable.newBuilder()
+        .setName("CHRONOS_RESOURCE_DISK").setValue(job.disk.toString))
+
     // If the job defines custom environment variables, add them to the builder
     // Don't add them if they already exist to prevent overwriting the defaults
     val builtinEnvNames = environment.getVariablesList().asScala.map(_.getName()).toSet


### PR DESCRIPTION
This adds the following environment variables and their purpose

CHRONOS_RESOURCE_CPU  - The CPU resources allocated to this job
CHRONOS_RESOURCE_DISK - The disk resources allocated to this job
CHRONOS_RESOURCE_MEM  - Tme memory resources allocated to this job

The value in these is certain programs (like the JVM) can use these
values to optimize how they run (like setting the -xmx parameter).
Honestly Mesos should do this but I figure it doesn't hurt to put
it here and later have Mesos provide it too.
