### PR TITLE
Support for custom command arguments when manually running a Chronos job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ chronos.arx
 chronos.tbz
 .classpath.txt
 dependency-reduced-pom.xml
+.arcconfig

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ You can manually start a job by issuing an HTTP request.
 
 * Endpoint: __/scheduler/job__
 * Method: __PUT__
-* Query string parameters: `arguments` - optional string with a list of command line arguments that is appended to job's `command` (if `shell` is true) or `arguments` (if `shell` is false)
+* Query string parameters: `arguments` - optional string with a list of command line arguments that is appended to job's `command`
 * Example: `curl -L -X PUT chronos-node:8080/scheduler/job/request_event_counter_hourly`
 * Example: `curl -L -X PUT chronos-node:8080/scheduler/job/job_name?arguments=-debug%20true`
 * Response: HTTP 204

--- a/README.md
+++ b/README.md
@@ -178,7 +178,9 @@ You can manually start a job by issuing an HTTP request.
 
 * Endpoint: __/scheduler/job__
 * Method: __PUT__
+* Query string parameters: `arguments` - optional string with a list of command line arguments that is appended to job's `command` (if `shell` is true) or `arguments` (if `shell` is false)
 * Example: `curl -L -X PUT chronos-node:8080/scheduler/job/request_event_counter_hourly`
+* Example: `curl -L -X PUT chronos-node:8080/scheduler/job/job_name?arguments=-debug%20true`
 * Response: HTTP 204
 
 ### Adding a Scheduled Job

--- a/pom.xml
+++ b/pom.xml
@@ -380,7 +380,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugins.version}</version>
         <configuration>
-          <argLine>-Xmx1024m</argLine>
+          <argLine>-Xmx1024m -Duser.timezone=UTC</argLine>
           <redirectTestOutputToFile>false</redirectTestOutputToFile>
           <includes>
             <include>**/Test*.java</include>

--- a/src/main/scala/com/airbnb/scheduler/api/JobManagementResource.scala
+++ b/src/main/scala/com/airbnb/scheduler/api/JobManagementResource.scala
@@ -126,12 +126,14 @@ class JobManagementResource @Inject()(val jobScheduler: JobScheduler,
   @Path(PathConstants.jobPatternPath)
   @PUT
   @Timed
-  def trigger(@PathParam("jobName") jobName: String): Response = {
+  def trigger(@PathParam("jobName") jobName: String,
+              @QueryParam("arguments") arguments: String
+              ): Response = {
     try {
       require(!jobGraph.lookupVertex(jobName).isEmpty, "Job '%s' not found".format(jobName))
       val job = jobGraph.getJobForName(jobName).get
       log.info("Manually triggering job:" + jobName)
-      jobScheduler.taskManager.enqueue(TaskUtils.getTaskId(job, DateTime.now(DateTimeZone.UTC), 0), job.highPriority)
+      jobScheduler.taskManager.enqueue(TaskUtils.getTaskId(job, DateTime.now(DateTimeZone.UTC), 0, arguments), job.highPriority)
       Response.noContent().build
     } catch {
       case ex: IllegalArgumentException => {

--- a/src/main/scala/com/airbnb/scheduler/jobs/JobScheduler.scala
+++ b/src/main/scala/com/airbnb/scheduler/jobs/JobScheduler.scala
@@ -90,7 +90,7 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
   }
 
   def isTaskAsync(taskId: String): Boolean = {
-    val TaskUtils.taskIdPattern(_, _, jobName) = taskId
+    val TaskUtils.taskIdPattern(_, _, jobName, _) = taskId
     jobGraph.lookupVertex(jobName) match {
       case Some(baseJob: BaseJob) => baseJob.async
       case _ => false
@@ -254,7 +254,7 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
       log.warning("Job '%s' no longer registered.".format(jobName))
     } else {
       val job = jobOption.get
-      val (_, _, attempt) = TaskUtils.parseTaskId(taskId)
+      val (_, _, attempt, _) = TaskUtils.parseTaskId(taskId)
       jobStats.jobStarted(job, taskStatus, attempt)
 
       job match {
@@ -282,7 +282,7 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
     if (jobOption.isEmpty) {
       log.warning("Job '%s' no longer registered.".format(jobName))
     } else {
-      val (_, start, attempt) = TaskUtils.parseTaskId(taskId)
+      val (_, start, attempt, _) = TaskUtils.parseTaskId(taskId)
       jobMetrics.updateJobStat(jobName, timeMs = DateTime.now(DateTimeZone.UTC).getMillis - start)
       jobMetrics.updateJobStatus(jobName, success = true)
       val job = jobOption.get
@@ -368,7 +368,7 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
     if (!TaskUtils.isValidVersion(taskId)) {
       log.warning("Found old or invalid task, ignoring!")
     } else {
-      val (jobName, _, attempt) = TaskUtils.parseTaskId(taskId)
+      val (jobName, _, attempt, _) = TaskUtils.parseTaskId(taskId)
       log.warning("Task of job: %s failed.".format(jobName))
       val jobOption = jobGraph.lookupVertex(jobName)
       jobOption match {

--- a/src/main/scala/com/airbnb/scheduler/jobs/JobUtils.scala
+++ b/src/main/scala/com/airbnb/scheduler/jobs/JobUtils.scala
@@ -159,12 +159,13 @@ object JobUtils {
   }
 
   def getJobWithArguments(job: BaseJob, arguments: String): BaseJob = {
+    val commandWithArgs = job.command + " " + arguments;
     val jobWithArguments = job match {
       case j: DependencyBasedJob =>
         new DependencyBasedJob(
           parents = Set(),
           name = job.name,
-          command = if (job.shell) (job.command + " " + arguments) else job.command,
+          command = commandWithArgs,
           epsilon = job.epsilon,
           successCount = job.successCount,
           errorCount = job.errorCount,
@@ -187,14 +188,14 @@ object JobUtils {
           container = job.container,
           environmentVariables = job.environmentVariables,
           shell = job.shell,
-          arguments = if (job.shell) job.arguments else (job.arguments ++ List(arguments))
+          arguments = job.arguments
         )
       case j: ScheduleBasedJob =>
         new ScheduleBasedJob(
           schedule = j.schedule,
           scheduleTimeZone = j.scheduleTimeZone,
           name = job.name,
-          command = if (job.shell) (job.command + " " + arguments) else job.command,
+          command = commandWithArgs,
           epsilon = job.epsilon,
           successCount = job.successCount,
           errorCount = job.errorCount,
@@ -217,7 +218,7 @@ object JobUtils {
           container = job.container,
           environmentVariables = job.environmentVariables,
           shell = job.shell,
-          arguments = if (job.shell) job.arguments else (job.arguments ++ List(arguments))
+          arguments = job.arguments
         )
     }
     jobWithArguments

--- a/src/main/scala/com/airbnb/scheduler/jobs/JobUtils.scala
+++ b/src/main/scala/com/airbnb/scheduler/jobs/JobUtils.scala
@@ -157,4 +157,69 @@ object JobUtils {
       Seconds.secondsBetween(jobStart, dateTime).getSeconds / period.toStandardSeconds.getSeconds  
     }
   }
+
+  def getJobWithArguments(job: BaseJob, arguments: String): BaseJob = {
+    val jobWithArguments = job match {
+      case j: DependencyBasedJob =>
+        new DependencyBasedJob(
+          parents = Set(),
+          name = job.name,
+          command = if (job.shell) (job.command + " " + arguments) else job.command,
+          epsilon = job.epsilon,
+          successCount = job.successCount,
+          errorCount = job.errorCount,
+          executor = job.executor,
+          executorFlags = job.executorFlags,
+          retries = job.retries,
+          owner = job.owner,
+          lastError = job.lastError,
+          lastSuccess = job.lastSuccess,
+          async = job.async,
+          cpus = job.cpus,
+          disk = job.disk,
+          mem = job.mem,
+          disabled = job.disabled,
+          errorsSinceLastSuccess = job.errorsSinceLastSuccess,
+          softError = job.softError,
+          uris = job.uris,
+          highPriority = job.highPriority,
+          runAsUser = job.runAsUser,
+          container = job.container,
+          environmentVariables = job.environmentVariables,
+          shell = job.shell,
+          arguments = if (job.shell) job.arguments else (job.arguments ++ List(arguments))
+        )
+      case j: ScheduleBasedJob =>
+        new ScheduleBasedJob(
+          schedule = j.schedule,
+          scheduleTimeZone = j.scheduleTimeZone,
+          name = job.name,
+          command = if (job.shell) (job.command + " " + arguments) else job.command,
+          epsilon = job.epsilon,
+          successCount = job.successCount,
+          errorCount = job.errorCount,
+          executor = job.executor,
+          executorFlags = job.executorFlags,
+          retries = job.retries,
+          owner = job.owner,
+          lastError = job.lastError,
+          lastSuccess = job.lastSuccess,
+          async = job.async,
+          cpus = job.cpus,
+          disk = job.disk,
+          mem = job.mem,
+          disabled = job.disabled,
+          errorsSinceLastSuccess = job.errorsSinceLastSuccess,
+          softError = job.softError,
+          uris = job.uris,
+          highPriority = job.highPriority,
+          runAsUser = job.runAsUser,
+          container = job.container,
+          environmentVariables = job.environmentVariables,
+          shell = job.shell,
+          arguments = if (job.shell) job.arguments else (job.arguments ++ List(arguments))
+        )
+    }
+    jobWithArguments
+  }
 }

--- a/src/main/scala/com/airbnb/scheduler/jobs/TaskManager.scala
+++ b/src/main/scala/com/airbnb/scheduler/jobs/TaskManager.scala
@@ -73,11 +73,18 @@ class TaskManager @Inject()(val listeningExecutor: ListeningScheduledExecutorSer
     } else {
       log.info(s"$name queue contains task: $taskId")
       val jobOption = jobGraph.getJobForName(TaskUtils.getJobNameForTaskId(taskId))
+      val jobArguments = TaskUtils.getJobArgumentsForTaskId(taskId)
+      var job = jobOption.get
+
+      if (jobArguments!= null && !jobArguments.isEmpty) {
+        job = JobUtils.getJobWithArguments(job, jobArguments)
+      }
+
       //If the job was deleted after the taskId was added to the queue, the task could be empty.
       if (jobOption.isEmpty || jobOption.get.disabled) {
         None
       } else {
-        Some(taskId, jobOption.get)
+        Some(taskId, job)
       }
     }
   }

--- a/src/main/scala/com/airbnb/scheduler/mesos/MesosJobFramework.scala
+++ b/src/main/scala/com/airbnb/scheduler/mesos/MesosJobFramework.scala
@@ -218,7 +218,7 @@ class MesosJobFramework @Inject()(
   def statusUpdate(schedulerDriver: SchedulerDriver, taskStatus: TaskStatus) {
      taskManager.taskCache.put(taskStatus.getTaskId.getValue, taskStatus.getState)
 
-    val (jobName, _, _) = TaskUtils.parseTaskId(taskStatus.getTaskId.getValue)
+    val (jobName, _, _, _) = TaskUtils.parseTaskId(taskStatus.getTaskId.getValue)
     taskStatus.getState match {
       case TaskState.TASK_RUNNING =>
         scheduler.handleStartedTask(taskStatus)

--- a/src/test/scala/com/airbnb/scheduler/jobs/JobUtilsSpec.scala
+++ b/src/test/scala/com/airbnb/scheduler/jobs/JobUtilsSpec.scala
@@ -50,4 +50,29 @@ class JobUtilsSpec extends SpecificationWithJUnit with Mockito {
     scheduledTime.isAfter(now) must beTrue
     scheduledTime.dayOfMonth().get must_== 1
   }
+  
+  "Can get job with arguments" in {
+    val schedule = "R/2012-01-01T00:00:01.000Z/P1M"
+    val arguments = "--help"
+    val command = "sample-command"
+    val commandWithArguments = command + " " +arguments
+
+    // Using shell: true
+    val scheduledJob = new ScheduleBasedJob(schedule, "sample-name", command = command)
+    val dependencyJob = new DependencyBasedJob(parents=Set("sample-name"), "sample-name2", command = command)
+    val scheduledJobWithArguments = JobUtils.getJobWithArguments(scheduledJob, arguments)
+    val dependencyJobWithArguments = JobUtils.getJobWithArguments(dependencyJob, arguments)
+
+    scheduledJobWithArguments.command.toString() must_== commandWithArguments
+    dependencyJobWithArguments.command.toString() must_== commandWithArguments
+
+    // Using shell: false
+    val scheduledJobNoShell = new ScheduleBasedJob(schedule, "sample-name3", command = command, shell = false)
+    val dependencyJobNoShell = new DependencyBasedJob(parents=Set("sample-name3"), "sample-name4", command = command, shell = false)
+    val scheduledJobWithArgumentsNoShell = JobUtils.getJobWithArguments(scheduledJobNoShell, arguments)
+    val dependencyJobWithArgumentsNoShell = JobUtils.getJobWithArguments(dependencyJobNoShell, arguments)
+
+    scheduledJobWithArgumentsNoShell.arguments.mkString(" ") must_== arguments
+    dependencyJobWithArgumentsNoShell.arguments.mkString(" ") must_== arguments
+  }
 }

--- a/src/test/scala/com/airbnb/scheduler/jobs/JobUtilsSpec.scala
+++ b/src/test/scala/com/airbnb/scheduler/jobs/JobUtilsSpec.scala
@@ -57,7 +57,6 @@ class JobUtilsSpec extends SpecificationWithJUnit with Mockito {
     val command = "sample-command"
     val commandWithArguments = command + " " +arguments
 
-    // Using shell: true
     val scheduledJob = new ScheduleBasedJob(schedule, "sample-name", command = command)
     val dependencyJob = new DependencyBasedJob(parents=Set("sample-name"), "sample-name2", command = command)
     val scheduledJobWithArguments = JobUtils.getJobWithArguments(scheduledJob, arguments)
@@ -65,14 +64,5 @@ class JobUtilsSpec extends SpecificationWithJUnit with Mockito {
 
     scheduledJobWithArguments.command.toString() must_== commandWithArguments
     dependencyJobWithArguments.command.toString() must_== commandWithArguments
-
-    // Using shell: false
-    val scheduledJobNoShell = new ScheduleBasedJob(schedule, "sample-name3", command = command, shell = false)
-    val dependencyJobNoShell = new DependencyBasedJob(parents=Set("sample-name3"), "sample-name4", command = command, shell = false)
-    val scheduledJobWithArgumentsNoShell = JobUtils.getJobWithArguments(scheduledJobNoShell, arguments)
-    val dependencyJobWithArgumentsNoShell = JobUtils.getJobWithArguments(dependencyJobNoShell, arguments)
-
-    scheduledJobWithArgumentsNoShell.arguments.mkString(" ") must_== arguments
-    dependencyJobWithArgumentsNoShell.arguments.mkString(" ") must_== arguments
   }
 }

--- a/src/test/scala/com/airbnb/scheduler/jobs/TaskUtilsSpec.scala
+++ b/src/test/scala/com/airbnb/scheduler/jobs/TaskUtilsSpec.scala
@@ -1,0 +1,61 @@
+package com.airbnb.scheduler.jobs
+
+import com.airbnb.scheduler.state.PersistenceStore
+import com.google.common.util.concurrent.{ListeningScheduledExecutorService}
+import org.joda.time._
+import org.specs2.mock._
+import org.specs2.mutable._
+import com.airbnb.scheduler.graph.JobGraph
+import com.codahale.metrics.MetricRegistry
+
+class TaskUtilsSpec extends SpecificationWithJUnit with Mockito {
+
+  "TaskUtils" should {
+    "Get taskId" in {
+      val schedule = "R/2012-01-01T00:00:01.000Z/P1M"
+      val job = new ScheduleBasedJob(schedule, "sample-name", "sample-command")
+      val ts = 1420843781398L
+      val due = new DateTime(ts)
+      val arguments = "-a 1 -b 2"
+
+      val taskIdOne = TaskUtils.getTaskId(job, due, 0, arguments)
+      val taskIdTwo = TaskUtils.getTaskId(job, due, 0)
+
+      taskIdOne must_== "ct:1420843781398:0:sample-name:" + arguments
+      taskIdTwo must_== "ct:1420843781398:0:sample-name:"
+    }
+
+    "Get job arguments for taskId" in {
+      val arguments = "-a 1 -b 2"
+      var taskId = "ct:1420843781398:0:test:" + arguments
+      val jobArguments = TaskUtils.getJobArgumentsForTaskId(taskId)
+
+      jobArguments must_== arguments
+    }
+
+    "Parse taskId" in {
+      val arguments = "-a 1 -b 2"
+      val arguments2 = "-a 1:2 --B test"
+
+      val taskIdOne = "ct:1420843781398:0:test:" + arguments
+      val (jobName, jobDue, attempt, jobArguments) = TaskUtils.parseTaskId(taskIdOne)
+
+      jobName must_== "test"
+      jobDue must_== 1420843781398L
+      attempt must_== 0
+      jobArguments must_== arguments
+
+      val taskIdTwo = "ct:1420843781398:0:test:" + arguments2
+      val (_, _, _, jobArguments2) = TaskUtils.parseTaskId(taskIdTwo)
+
+      jobArguments2 must_== arguments2
+
+      val taskIdThree = "ct:1420843781398:0:test"
+      val (jobName3, _, _, jobArguments3) = TaskUtils.parseTaskId(taskIdThree)
+
+      jobName3 must_== "test"
+      jobArguments3 must_== ""
+    }
+  }
+}
+


### PR DESCRIPTION
This commit adds support for passing custom command arguments when manually running a Chronos job using `PUT /scheduler/<jobName>` endpoint

see https://github.com/airbnb/chronos/issues/335