### PR TITLE
Remove invalid tasks on scheduling

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
@@ -83,9 +83,11 @@ class TaskManager @Inject()(val listeningExecutor: ListeningScheduledExecutorSer
       }
 
       //If the job was deleted after the taskId was added to the queue, the task could be empty.
-      if (jobOption.isEmpty || jobOption.get.disabled) {
+      if (jobOption.isEmpty} {
         //remove invalid task
         removeTask(taskId)
+        None
+      } else if (jobOption.get.disabled) {
         None
       } else {
         Some(taskId, job)

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
@@ -83,7 +83,7 @@ class TaskManager @Inject()(val listeningExecutor: ListeningScheduledExecutorSer
       }
 
       //If the job was deleted after the taskId was added to the queue, the task could be empty.
-      if (jobOption.isEmpty} {
+      if (jobOption.isEmpty) {
         //remove invalid task
         removeTask(taskId)
         None

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
@@ -84,6 +84,8 @@ class TaskManager @Inject()(val listeningExecutor: ListeningScheduledExecutorSer
 
       //If the job was deleted after the taskId was added to the queue, the task could be empty.
       if (jobOption.isEmpty || jobOption.get.disabled) {
+        //remove invalid task
+        removeTask(taskId)
         None
       } else {
         Some(taskId, job)


### PR DESCRIPTION
Task will be loaded on restarting. It's meaningless.