### PR TITLE
Task flow parameters

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/ChronosRestModule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/ChronosRestModule.scala
@@ -60,6 +60,7 @@ class ChronosRestModule extends ServletModule {
 
     bind(classOf[Iso8601JobResource]).in(Scopes.SINGLETON)
     bind(classOf[DependentJobResource]).in(Scopes.SINGLETON)
+    bind(classOf[TriggeredJobResource]).in(Scopes.SINGLETON)
     bind(classOf[JobManagementResource]).in(Scopes.SINGLETON)
     bind(classOf[TaskManagementResource]).in(Scopes.SINGLETON)
     bind(classOf[GraphManagementResource]).in(Scopes.SINGLETON)

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/PathConstants.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/PathConstants.scala
@@ -6,10 +6,12 @@ package org.apache.mesos.chronos.scheduler.api
 object PathConstants {
   final val iso8601JobPath = "/iso8601"
   final val dependentJobPath = "/dependency"
+  final val triggeredJobPath = "/triggered"
   final val infoPath = "/info"
 
   final val jobBasePath = "/"
   final val jobPatternPath = "job/{jobName}"
+  final val triggerJobPatternPath = "job/trigger/{jobName}"
   final val allJobsPath = "jobs"
   final val jobSearchPath = "jobs/search"
   final val allStatsPath = "stats/{percentile}"

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/TriggeredJobResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/TriggeredJobResource.scala
@@ -1,0 +1,79 @@
+package org.apache.mesos.chronos.scheduler.api
+
+import java.util.logging.{Level, Logger}
+import javax.ws.rs.core.{MediaType, Response}
+import javax.ws.rs._
+
+import com.codahale.metrics.annotation.Timed
+import com.google.common.base.Charsets
+import com.google.inject.Inject
+import org.apache.mesos.chronos.scheduler.graph.JobGraph
+import org.apache.mesos.chronos.scheduler.jobs._
+
+/**
+ * The REST API for adding triggered jobs to the scheduler.
+ */
+@Path(PathConstants.triggeredJobPath)
+@Produces(Array(MediaType.APPLICATION_JSON))
+class TriggeredJobResource @Inject()(
+                                      val jobScheduler: JobScheduler,
+                                      val jobGraph: JobGraph) {
+
+  private[this] val log = Logger.getLogger(getClass.getName)
+
+  @POST
+  @Timed
+  def post(newJob: TriggeredJob): Response = {
+    handleRequest(newJob)
+  }
+
+  def handleRequest(newJob: TriggeredJob): Response = {
+    try {
+      val oldJobOpt = jobGraph.lookupVertex(newJob.name)
+      if (oldJobOpt.isEmpty) {
+        log.info("Received request for job:" + newJob.toString)
+
+        require(JobUtils.isValidJobName(newJob.name),
+          "the job's name is invalid. Allowed names: '%s'".format(JobUtils.jobNamePattern.toString()))
+
+        jobScheduler.registerJob(List(newJob), persist = true)
+        Response.noContent().build()
+      } else {
+        require(oldJobOpt.isDefined, "Job '%s' not found".format(newJob.name))
+
+        val oldJob = oldJobOpt.get
+
+        //TODO(FL): Ensure we're using job-ids rather than relying on jobs names for identification.
+        assert(newJob.name == oldJob.name, "Renaming jobs is currently not supported!")
+
+        log.info("Received replace request for job:" + newJob.toString)
+        require(jobGraph.lookupVertex(newJob.name).isDefined, "Job '%s' not found".format(newJob.name))
+        //TODO(FL): Put all the logic for registering, deregistering and replacing dependency based jobs into one place.
+
+        jobScheduler.updateJob(oldJob, newJob)
+
+        log.info("Replaced job: '%s', oldJob: '%s', newJob: '%s'".format(
+          newJob.name,
+          new String(JobUtils.toBytes(oldJob), Charsets.UTF_8),
+          new String(JobUtils.toBytes(newJob), Charsets.UTF_8)))
+
+        Response.noContent().build()
+      }
+    } catch {
+      case ex: IllegalArgumentException =>
+        log.log(Level.INFO, "Bad Request", ex)
+        Response.status(Response.Status.BAD_REQUEST).entity(ex.getMessage)
+          .build()
+      case ex: Exception =>
+        log.log(Level.WARNING, "Exception while serving request", ex)
+        Response.serverError().build()
+    }
+  }
+
+  @PUT
+  @Timed
+  def put(newJob: TriggeredJob): Response = {
+    handleRequest(newJob)
+  }
+
+}

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/graph/JobGraph.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/graph/JobGraph.scala
@@ -121,6 +121,7 @@ class JobGraph {
     }
   }
 
+
   /**
    * Retrieves all the jobs that need to be triggered that depend on the finishedJob.
    * @param vertex
@@ -170,6 +171,14 @@ class JobGraph {
     results.toList
   }
 
+  /**
+   * Indicates if a node has dependencies. This is useful for task flow cleanup.
+   * @return 
+   */
+  def hasChildren(vertex: String): Boolean = {
+    getChildren(vertex).size > 0
+  }
+  
   def getChildren(job: String): Iterable[String] = {
     import scala.collection.JavaConversions._
     lock.synchronized {

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
@@ -377,7 +377,9 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
           }
       })
     } else {
-      taskFlowId map persistenceStore.removeTaskFlowState
+      if (!jobGraph.hasChildren(jobName)) 
+        taskFlowId map persistenceStore.removeTaskFlowState
+      
       log.fine("%s does not have any ready dependents.".format(jobName))
     }
   }

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
@@ -72,7 +72,7 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
   }
 
   def isTaskAsync(taskId: String): Boolean = {
-    val TaskUtils.taskIdPattern(_, _, jobName, _) = taskId
+    val TaskUtils.taskIdPattern(_, _, jobName, _, _) = taskId
     jobGraph.lookupVertex(jobName) match {
       case Some(baseJob: BaseJob) => baseJob.async
       case _ => false
@@ -133,12 +133,15 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
       require(isLeader, "Cannot register a job with this scheduler, not the leader!")
       val scheduleBasedJobs = ListBuffer[ScheduleBasedJob]()
       val dependencyBasedJobs = ListBuffer[DependencyBasedJob]()
+      val triggeredJobs = ListBuffer[TriggeredJob]()
 
       jobs.foreach {
         case x: DependencyBasedJob =>
           dependencyBasedJobs += x
         case x: ScheduleBasedJob =>
           scheduleBasedJobs += x
+        case x: TriggeredJob =>
+          triggeredJobs += x
         case x: Any =>
           throw new IllegalStateException("Error, job is neither ScheduleBased nor DependencyBased:" + x.toString)
 
@@ -172,6 +175,14 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
             }
         })
       }
+      
+      triggeredJobs foreach { job =>
+        jobGraph.addVertex(job)
+        if (persist) {
+          log.info("Persisting job:" + job.name)
+          persistenceStore.persistJob(job)
+        }
+      }
     }
   }
 
@@ -201,6 +212,9 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
           removeSchedule(scheduledJob)
           log.info("Removed schedule based job")
           log.info("Size of streams:" + streams.size)
+        case triggeredJob: TriggeredJob => 
+          //nothing to do here
+          log.info("Removed triggered job")
         case dependencyBasedJob: DependencyBasedJob =>
           //TODO(FL): Check if there are empty edges.
           log.info("Job removed from dependency graph.")
@@ -231,7 +245,7 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
       log.warning("Job '%s' no longer registered.".format(jobName))
     } else {
       val job = jobOption.get
-      val (_, _, attempt, _) = TaskUtils.parseTaskId(taskId)
+      val (_, _, attempt, _, _) = TaskUtils.parseTaskId(taskId)
       jobStats.jobStarted(job, taskStatus, attempt)
 
       job match {
@@ -241,11 +255,11 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
       }
     }
   }
-
+  
   /**
    * Takes care of follow-up actions for a finished task, i.e. update the job schedule in the persistence store or
    * launch tasks for dependent jobs
-   * @param taskId
+   * @param taskStatus
    */
   def handleFinishedTask(taskStatus: TaskStatus, taskDate: Option[DateTime] = None) {
     // `taskDate` is purely for unit testing
@@ -260,12 +274,12 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
     if (jobOption.isEmpty) {
       log.warning("Job '%s' no longer registered.".format(jobName))
     } else {
-      val (_, start, attempt, _) = TaskUtils.parseTaskId(taskId)
+      val (_, start, attempt, _, _) = TaskUtils.parseTaskId(taskId)
       jobMetrics.updateJobStat(jobName, timeMs = DateTime.now(DateTimeZone.UTC).getMillis - start)
       jobMetrics.updateJobStatus(jobName, success = true)
       val job = jobOption.get
       jobStats.jobFinished(job, taskStatus, attempt)
-
+      
       val newJob = job match {
         case job: ScheduleBasedJob =>
           job.copy(successCount = job.successCount + 1,
@@ -275,11 +289,17 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
           job.copy(successCount = job.successCount + 1,
             errorsSinceLastSuccess = 0,
             lastSuccess = DateTime.now(DateTimeZone.UTC).toString)
+        case job: TriggeredJob =>
+          job.copy(successCount = job.successCount + 1,
+            errorsSinceLastSuccess = 0,
+            lastSuccess = DateTime.now(DateTimeZone.UTC).toString)
         case _ =>
           throw new IllegalArgumentException("Cannot handle unknown task type")
       }
       replaceJob(job, newJob)
-      processDependencies(jobName, taskDate)
+
+      val taskFlowId = TaskUtils.getTaskFlowId(taskId)
+      processDependencies(jobName, taskDate, taskFlowId)
 
       log.fine("Cleaning up finished task '%s'".format(taskId))
 
@@ -337,7 +357,7 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
     }
   }
 
-  private def processDependencies(jobName: String, taskDate: Option[DateTime]) {
+  private def processDependencies(jobName: String, taskDate: Option[DateTime], taskFlowId: Option[String]) {
     val dependents = jobGraph.getExecutableChildren(jobName)
     if (dependents.nonEmpty) {
       log.fine("%s has dependents: %s .".format(jobName, dependents.mkString(",")))
@@ -351,12 +371,13 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
               case None => DateTime.now(DateTimeZone.UTC)
             }
             taskManager.enqueue(TaskUtils.getTaskId(dependentJob,
-              date), dependentJob.highPriority)
+              date, 0, taskFlowId), dependentJob.highPriority)
 
             log.fine("Enqueued depedent job." + x)
           }
       })
     } else {
+      taskFlowId map persistenceStore.removeTaskFlowState
       log.fine("%s does not have any ready dependents.".format(jobName))
     }
   }
@@ -371,12 +392,13 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
     if (!TaskUtils.isValidVersion(taskId)) {
       log.warning("Found old or invalid task, ignoring!")
     } else {
-      val (jobName, _, attempt, _) = TaskUtils.parseTaskId(taskId)
+      val (jobName, _, attempt, _, _) = TaskUtils.parseTaskId(taskId)
       log.warning("Task of job: %s failed.".format(jobName))
       val jobOption = jobGraph.lookupVertex(jobName)
       jobOption match {
         case Some(job) =>
           jobStats.jobFailed(job, taskStatus, attempt)
+          val taskFlowId = TaskUtils.getTaskFlowId(taskId)
 
           val hasAttemptsLeft: Boolean = attempt < job.retries
           val hadRecentSuccess: Boolean = try {
@@ -388,17 +410,17 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
               false
             case _: Exception => false
           }
-
           if (hasAttemptsLeft && (job.lastError.length == 0 || hadRecentSuccess)) {
             log.warning("Retrying job: %s, attempt: %d".format(jobName, attempt))
             /* Schedule the retry up to 60 seconds in the future */
             val delayDuration = new Duration(failureRetryDelay)
             val newTaskId = TaskUtils.getTaskId(job, DateTime.now(DateTimeZone.UTC)
-              .plus(delayDuration), attempt + 1)
+              .plus(delayDuration), attempt + 1, taskFlowId)
             val delayedTask = new Runnable {
               def run() {
                 log.info(s"Enqueuing failed task $newTaskId")
                 taskManager.persistTask(newTaskId, job)
+
                 taskManager.enqueue(newTaskId, job.highPriority)
               }
             }
@@ -410,7 +432,6 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
           } else {
             val disableJob =
               (disableAfterFailures > 0) && (job.errorsSinceLastSuccess + 1 >= disableAfterFailures)
-
             val lastErrorTime = DateTime.now(DateTimeZone.UTC)
             val newJob = {
               job match {
@@ -426,7 +447,9 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
               }
             }
             updateJob(job, newJob)
-            if (job.softError) processDependencies(jobName, Option(lastErrorTime))
+            if (job.softError) processDependencies(jobName, Option(lastErrorTime), taskFlowId)
+            else taskFlowId map persistenceStore.removeTaskFlowState
+
 
             val clusterPrefix = getClusterPrefix(clusterName)
 

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
@@ -61,12 +61,13 @@ object JobUtils {
     //TODO(FL): Create functions that map strings to jobs
     val scheduledJobs = new ListBuffer[ScheduleBasedJob]
     val dependencyBasedJobs = new ListBuffer[DependencyBasedJob]
-
+    val triggeredJobs = new ListBuffer[TriggeredJob]
     val jobs = store.getJobs
 
     jobs.foreach {
       case d: DependencyBasedJob => dependencyBasedJobs += d
       case s: ScheduleBasedJob => scheduledJobs += s
+      case t: TriggeredJob => triggeredJobs += t
       case x: Any =>
         throw new IllegalStateException("Error, job is neither ScheduleBased nor DependencyBased:" + x.toString)
     }
@@ -97,6 +98,10 @@ object JobUtils {
                 scheduler.jobGraph.addDependency(y.name, x.name)
             }
         }
+    }
+    
+    triggeredJobs.foreach { job =>
+      scheduler.jobGraph.addVertex(job)
     }
   }
 

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Jobs.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Jobs.scala
@@ -1,8 +1,8 @@
 package org.apache.mesos.chronos.scheduler.jobs
 
-import org.apache.mesos.chronos.utils.JobDeserializer
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.{JsonCreator, JsonInclude, JsonProperty}
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import org.apache.mesos.chronos.utils.JobDeserializer
 import org.joda.time.{Minutes, Period}
 
 /**
@@ -104,6 +104,34 @@ case class ScheduleBasedJob(
                              @JsonProperty override val softError: Boolean = false)
   extends BaseJob
 
+@JsonDeserialize(using = classOf[JobDeserializer])
+case class TriggeredJob(
+                         @JsonProperty override val name: String,
+                         @JsonProperty override val command: String,
+                         @JsonProperty override val epsilon: Period = Minutes.minutes(5).toPeriod,
+                         @JsonProperty override val successCount: Long = 0L,
+                         @JsonProperty override val errorCount: Long = 0L,
+                         @JsonProperty override val executor: String = "",
+                         @JsonProperty override val executorFlags: String = "",
+                         @JsonProperty override val retries: Int = 2,
+                         @JsonProperty override val owner: String = "",
+                         @JsonProperty override val lastSuccess: String = "",
+                         @JsonProperty override val lastError: String = "",
+                         @JsonProperty override val async: Boolean = false,
+                         @JsonProperty override val cpus: Double = 0,
+                         @JsonProperty override val disk: Double = 0,
+                         @JsonProperty override val mem: Double = 0,
+                         @JsonProperty override val disabled: Boolean = false,
+                         @JsonProperty override val errorsSinceLastSuccess: Long = 0L,
+                         @JsonProperty override val uris: Seq[String] = List(),
+                         @JsonProperty override val highPriority: Boolean = false,
+                         @JsonProperty override val runAsUser: String = "",
+                         @JsonProperty override val container: DockerContainer = null,
+                         @JsonProperty override val environmentVariables: Seq[EnvironmentVariable] = List(),
+                         @JsonProperty override val shell: Boolean = true,
+                         @JsonProperty override val arguments: Seq[String] = List(),
+                         @JsonProperty override val softError: Boolean = false)
+  extends BaseJob
 
 @JsonDeserialize(using = classOf[JobDeserializer])
 case class DependencyBasedJob(
@@ -134,3 +162,8 @@ case class DependencyBasedJob(
                                @JsonProperty override val arguments: Seq[String] = List(),
                                @JsonProperty override val softError: Boolean = false)
   extends BaseJob
+
+@JsonDeserialize
+@JsonCreator
+@JsonInclude(JsonInclude.Include.ALWAYS)
+class TaskFlowState(@JsonProperty("id") val id: String, @JsonProperty("env") val env: Map[String, String])

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/state/PersistenceStore.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/state/PersistenceStore.scala
@@ -8,12 +8,33 @@ import org.apache.mesos.chronos.scheduler.jobs._
 trait PersistenceStore {
 
   /**
+   * Removes the task flow state
+   * @param id The task flow state id
+   * @return
+   */
+  def removeTaskFlowState(id: String): Boolean
+  
+  /**
+   * Retreives the task flow state
+   * @param id The task flow state id
+   * @return
+   */
+  def getTaskFlowState(id: String): TaskFlowState
+  
+  /**
+   * Persists the state for a task flow
+   * @param state The state to save
+   * @return true if state was saved, false otherwise
+   */
+  def persistTaskFlowState(state: TaskFlowState): Boolean
+  
+  /**
    * Persists a job with the underlying persistence store
    * @param job
    * @return
    */
   def persistJob(job: BaseJob): Boolean
-
+  
   /**
    * Saves a taskId in the state abstraction.
    * @param name the name of the taks to persist.

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
@@ -1,7 +1,7 @@
 package org.apache.mesos.chronos.utils
 
 import org.apache.mesos.chronos.scheduler.config.SchedulerConfiguration
-import org.apache.mesos.chronos.scheduler.jobs.{BaseJob, DependencyBasedJob, DockerContainer, EnvironmentVariable, NetworkMode, ScheduleBasedJob, Volume, VolumeMode}
+import org.apache.mesos.chronos.scheduler.jobs._
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer, JsonNode}
@@ -159,6 +159,14 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
         parentList += parent.asText
       }
       new DependencyBasedJob(parents = parentList.toSet,
+        name = name, command = command, epsilon = epsilon, successCount = successCount, errorCount = errorCount,
+        executor = executor, executorFlags = executorFlags, retries = retries, owner = owner, lastError = lastError,
+        lastSuccess = lastSuccess, async = async, cpus = cpus, disk = disk, mem = mem, disabled = disabled,
+        errorsSinceLastSuccess = errorsSinceLastSuccess, uris = uris, highPriority = highPriority,
+        runAsUser = runAsUser, container = container, environmentVariables = environmentVariables, shell = shell,
+        arguments = arguments, softError = softError)
+    } else if (node.has("triggeredJob")) {
+      TriggeredJob(
         name = name, command = command, epsilon = epsilon, successCount = successCount, errorCount = errorCount,
         executor = executor, executorFlags = executorFlags, retries = retries, owner = owner, lastError = lastError,
         lastSuccess = lastSuccess, async = async, cpus = cpus, disk = disk, mem = mem, disabled = disabled,

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobSerializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobSerializer.scala
@@ -1,6 +1,6 @@
 package org.apache.mesos.chronos.utils
 
-import org.apache.mesos.chronos.scheduler.jobs.{BaseJob, DependencyBasedJob, ScheduleBasedJob}
+import org.apache.mesos.chronos.scheduler.jobs.{TriggeredJob, BaseJob, DependencyBasedJob, ScheduleBasedJob}
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.{JsonSerializer, SerializerProvider}
 
@@ -138,6 +138,9 @@ class JobSerializer extends JsonSerializer[BaseJob] {
         json.writeString(schedJob.schedule)
         json.writeFieldName("scheduleTimeZone")
         json.writeString(schedJob.scheduleTimeZone)
+      case triggeredJob: TriggeredJob =>
+        json.writeFieldName("triggeredJob")
+        json.writeString("true")
       case _ =>
         throw new IllegalStateException("The job found was neither schedule based nor dependency based.")
     }

--- a/src/main/scala/org/apache/mesos/chronos/utils/TaskFlowSerDe.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/TaskFlowSerDe.scala
@@ -1,0 +1,59 @@
+package org.apache.mesos.chronos.utils
+
+import com.fasterxml.jackson.core.{JsonGenerator, JsonParser}
+import com.fasterxml.jackson.databind._
+import com.fasterxml.jackson.databind.module.SimpleModule
+import org.apache.mesos.chronos.scheduler.jobs.TaskFlowState
+
+/**
+ * Serializer for TaskFlowState. It may be better to use a proper scala jackson library.
+ */
+object taskFlowSerde {
+
+  val mapper = new ObjectMapper
+  val mod = new SimpleModule("TaskFlowStateModule")
+  mod.addSerializer(classOf[TaskFlowState], new TaskFlowSerializer)
+  mod.addDeserializer(classOf[TaskFlowState], new TaskFlowDeserializer)
+  mapper.registerModule(mod)
+  
+  def serString(flowState: TaskFlowState) = mapper.writeValueAsString(flowState)
+  def serBytes(flowState: TaskFlowState) = mapper.writeValueAsBytes(flowState)
+
+  def deserialize(bytes: Array[Byte]) = mapper.readValue(bytes, classOf[TaskFlowState])
+  
+  class TaskFlowSerializer extends JsonSerializer[TaskFlowState]{
+    override def serialize(t: TaskFlowState, json: JsonGenerator, 
+                           serializerProvider: SerializerProvider): Unit = {
+      json.writeStartObject()
+      json.writeFieldName("id")
+      json.writeString(t.id)
+      
+      json.writeFieldName("env")
+      json.writeStartObject()
+      t.env map {case (key, value) =>
+        json.writeFieldName(key)
+        json.writeString(value)
+      }
+      json.writeEndObject()
+      json.writeEndObject()
+    }
+  }
+
+  class TaskFlowDeserializer extends JsonDeserializer[TaskFlowState] {
+    override def deserialize(jsonParser: JsonParser, 
+                             deserializationContext: DeserializationContext): TaskFlowState = {
+      val codec = jsonParser.getCodec
+      val node = codec.readTree[JsonNode](jsonParser)
+
+      val id = node.get("id").asText
+      val elements = node.get("env").elements()
+      val fields = node.get("env").fields()
+      var env : Map[String, String] = Map()
+      while (fields.hasNext) {
+        val next = fields.next()
+        env = env + (next.getKey -> next.getValue.asText())
+      }
+      new TaskFlowState(id, env)
+    }
+  }
+}

--- a/src/main/scala/org/apache/mesos/chronos/utils/TaskFlowSerDe.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/TaskFlowSerDe.scala
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.{JsonGenerator, JsonParser}
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.module.SimpleModule
 import org.apache.mesos.chronos.scheduler.jobs.TaskFlowState
+import scala.collection.convert.decorateAsScala._
 
 /**
  * Serializer for TaskFlowState. It may be better to use a proper scala jackson library.
@@ -46,13 +47,9 @@ object taskFlowSerde {
       val node = codec.readTree[JsonNode](jsonParser)
 
       val id = node.get("id").asText
-      val elements = node.get("env").elements()
-      val fields = node.get("env").fields()
-      var env : Map[String, String] = Map()
-      while (fields.hasNext) {
-        val next = fields.next()
-        env = env + (next.getKey -> next.getValue.asText())
-      }
+      val fields = node.get("env").fields().asScala
+      val env = (fields map (entry => entry.getKey -> entry.getValue.asText())).toMap
+
       new TaskFlowState(id, env)
     }
   }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtilsSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtilsSpec.scala
@@ -18,8 +18,8 @@ class TaskUtilsSpec extends SpecificationWithJUnit with Mockito {
       val taskIdOne = TaskUtils.getTaskId(job1, due, 0)
       val taskIdTwo = TaskUtils.getTaskId(job2, due, 0)
 
-      taskIdOne must_== "ct:1420843781398:0:sample-name:" + arguments
-      taskIdTwo must_== "ct:1420843781398:0:sample-name:"
+      taskIdOne must_== s"ct:1420843781398:0:sample-name:$arguments:"
+      taskIdTwo must_== "ct:1420843781398:0:sample-name::"
     }
 
     "Get job arguments for taskId" in {
@@ -32,23 +32,28 @@ class TaskUtilsSpec extends SpecificationWithJUnit with Mockito {
 
     "Parse taskId" in {
       val arguments = "-a 1 -b 2"
-      val arguments2 = "-a 1:2 --B test"
-
-      val taskIdOne = "ct:1420843781398:0:test:" + arguments
-      val (jobName, jobDue, attempt, jobArguments) = TaskUtils.parseTaskId(taskIdOne)
+      val taskFlowId = "taskflow1"
+      //job arguments cannot have ':' now...
+      val arguments2 = "-a 1 2 --B test"
+      val taskFlowId2 = "taskflow2"
+      
+      val taskIdOne = s"ct:1420843781398:0:test:$arguments:$taskFlowId"
+      val (jobName, jobDue, attempt, jobArguments, taskFlow) = TaskUtils.parseTaskId(taskIdOne)
 
       jobName must_== "test"
       jobDue must_== 1420843781398L
       attempt must_== 0
       jobArguments must_== arguments
+      taskFlow must_== taskFlowId
 
-      val taskIdTwo = "ct:1420843781398:0:test:" + arguments2
-      val (_, _, _, jobArguments2) = TaskUtils.parseTaskId(taskIdTwo)
+      val taskIdTwo = s"ct:1420843781398:0:test:$arguments2:$taskFlowId2"
+      val (_, _, _, jobArguments2, taskFlow2) = TaskUtils.parseTaskId(taskIdTwo)
 
       jobArguments2 must_== arguments2
+      taskFlow2 must_== taskFlowId2
 
       val taskIdThree = "ct:1420843781398:0:test"
-      val (jobName3, _, _, jobArguments3) = TaskUtils.parseTaskId(taskIdThree)
+      val (jobName3, _, _, jobArguments3, _) = TaskUtils.parseTaskId(taskIdThree)
 
       jobName3 must_== "test"
       jobArguments3 must_== ""


### PR DESCRIPTION
I have added two things here. 
  1) Task Flow Parameters 
  2) A triggered job type

1) I am trying to use chronos to kick off a long running chain of tasks that are performed on demand with set of parameters. There was a recent addition to add arguments to the trigger endpoint. However, these parameters were not propagated to dependent jobs (for good reason). Additionally, because of how there were implemented, the length of the arguments were limited to around 230 characters. 

To address this, I added a task flow state that gets persisted in zookeeper. It basically holds a list of environment variables to allow specialization of the arguments for each job on a per task basis. Additionally, I added a new endpoint to support receiving this parameter. Basic usage is as follows:
curl -L -X POST chronosNode:8080/scheduler/job/trigger/JobName -d '{"env":{"var1":"val1", "var2":"val2"}, "id":"UniqueTaskFlowId"}'

A job that has been configured with arguments such as: "--opt1 ${var1} --opt2 ${var2}" will run with  "--opt1 val1 --opt2 val2"

2) This feature starts to encourage a different usage pattern than is offered by a schedule based job. Basically, I didn't want my jobs getting disabled because they were not scheduled to run again. So, I added a job type that isn't scheduled and just waits to be triggered. This type is fully supported by the scheduler and api, but I have yet to start adding it to the web ui.

One thing that I did change is that the character ":" is no longer supported in the arguments set in the old trigger api. There are two solutions to this. First, we could flip the order of the order of the arguments and task flow id in the mesos task_id. Secondly, we could remove support for the arguments provided with the trigger api. That feature was added very recently and is possibly made redundant by these changes. 

 I would appreciate any feedback! Thanks! 
Also here is the feature request I made initially: https://github.com/mesos/chronos/issues/367