### PR TITLE
expose more job variables via yaml files

### DIFF
--- a/bin/chronos-sync.rb
+++ b/bin/chronos-sync.rb
@@ -112,6 +112,7 @@ def normalize_job(job)
   newjob.delete 'lastSuccess'
   newjob.delete 'lastError'
   newjob.delete 'errorsSinceLastSuccess'
+  newjob.delete 'disabled'
 
   # Define optional fields, if not present
   newjob['uris'] = [] if !newjob.include?('uris')

--- a/bin/chronos-sync.rb
+++ b/bin/chronos-sync.rb
@@ -112,12 +112,6 @@ def normalize_job(job)
   newjob.delete 'lastSuccess'
   newjob.delete 'lastError'
   newjob.delete 'errorsSinceLastSuccess'
-  newjob.delete 'async'
-  newjob.delete 'epsilon'
-  newjob.delete 'retries'
-  newjob.delete 'executor'
-  newjob.delete 'executorFlags'
-  newjob.delete 'disabled'
 
   # Define optional fields, if not present
   newjob['uris'] = [] if !newjob.include?('uris')


### PR DESCRIPTION
Expose more variables to yaml file, to allow an user to have more control over job management.