### PR TITLE
Add state (i.e. queued, running) tracking for a job lifecycle. Currently...

### DIFF
--- a/src/main/resources/assets/app/index.html
+++ b/src/main/resources/assets/app/index.html
@@ -62,7 +62,7 @@
             </div>
           </div>
           <div class="row-fluid results-header">
-            <div class="span9 header-name">
+            <div class="span6 header-name">
               <span>Name</span>
               <span class="toggle down">▼</span>
               <span class="toggle up hide">▲</span>
@@ -71,6 +71,9 @@
               <span>Last</span>
               <span class="toggle down">▼</span>
               <span class="toggle up hide">▲</span>
+            </div>
+            <div class="span3 header-last-run">
+              <span>State</span>
             </div>
           </div>
           <div class="results">

--- a/src/main/resources/assets/app/scripts/collections/job_graph.js
+++ b/src/main/resources/assets/app/scripts/collections/job_graph.js
@@ -21,7 +21,7 @@ define([
       Sync;
 
   csvKeys = {
-    node: ['type', 'name', 'lastRunStatus'],
+    node: ['type', 'name', 'lastRunStatus', 'currentState'],
     link: ['type', 'source', 'target']
   };
 
@@ -273,15 +273,17 @@ define([
       var _this = this,
           updateInAccessoryCollection;
 
-      updateInAccessoryCollection = function(model, value) {
+      updateInAccessoryCollection = function(model, key, value) {
         var cModel = c.get(model.id);
 
         if (!!cModel) {
-          cModel.set('lastRunStatus', value);
-          model.set({
-            lastError: cModel.get('lastError'),
-            lastSuccess: cModel.get('lastSuccess')
-          });
+          cModel.set(key, value);
+          if (key == 'lastRunStatus') {
+            model.set({
+              lastError: cModel.get('lastError'),
+              lastSuccess: cModel.get('lastSuccess')
+            });
+          }
         }
       };
 
@@ -291,7 +293,10 @@ define([
         sync: function(coll) {
           _this.each(function(model) {
             if (!(JobGraph.isNode(model))) { return; }
-            updateInAccessoryCollection(model, model.get('lastRunStatus'));
+            updateInAccessoryCollection(model, 'lastRunStatus', model.get('lastRunStatus'));
+            //this value only comes from graph call and not part of job json,
+            //hence only listen here and not below
+            updateInAccessoryCollection(model, 'currentState', model.get('currentState'));
           });
         }
       });
@@ -300,7 +305,7 @@ define([
         'change:lastRunStatus': updateInAccessoryCollection,
         reset: function(collection, options) {
           collection.each(function(model) {
-            updateInAccessoryCollection(model, model.get('lastRunStatus'));
+            updateInAccessoryCollection(model, 'lastRunStatus', model.get('lastRunStatus'));
           });
         }
       });

--- a/src/main/resources/assets/app/scripts/templates/job_item_view.hbs
+++ b/src/main/resources/assets/app/scripts/templates/job_item_view.hbs
@@ -1,5 +1,5 @@
 <li class="item" data-cid="{{cid}}">
-  <div class="span9 job-name">{{name}}</div>
+  <div class="span6 job-name">{{name}}</div>
   <div class="span3 last-run">
     <span class="count"
           data-rv-class-count-success="job.lastRunSuccess"
@@ -11,5 +11,9 @@
           data-animation="true"
           data-delay="{show: 500, hide: 100}"
           data-toggle="tooltip"></span>
+  </div>
+  <div class="span3 last-run">
+    <span class="count"
+          data-rv-text="job.currentState"></span>
   </div>
 </li>

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/GraphManagementResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/GraphManagementResource.scala
@@ -48,7 +48,7 @@ class GraphManagementResource @Inject()(
   def jsonGraph(): Response = {
     try {
       val buffer = new StringWriter
-      Exporter.export(buffer, jobGraph)
+      Exporter.export(buffer, jobGraph, jobScheduler)
       Response.ok(buffer.toString).build
     } catch {
       case ex: Exception =>

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobStats.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobStats.scala
@@ -6,71 +6,107 @@ import java.util.logging.{Level, Logger}
 import org.apache.mesos.chronos.scheduler.config.CassandraConfiguration
 import com.datastax.driver.core._
 import com.datastax.driver.core.exceptions.{DriverException, NoHostAvailableException, QueryExecutionException, QueryValidationException}
+import com.datastax.driver.core.Row
+import com.datastax.driver.core.querybuilder.{QueryBuilder, Insert}
 import com.google.inject.Inject
-import org.apache.mesos.Protos.TaskStatus
+import org.apache.mesos.Protos.{TaskState, TaskStatus}
+import org.joda.time.DateTime
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.{HashMap}
+
+object CurrentState extends Enumeration {
+  type CurrentState = Value
+  val idle, queued, running = Value
+}
 
 class JobStats @Inject()(clusterBuilder: Option[Cluster.Builder], config: CassandraConfiguration) {
+
+  // Cassandra table column names
+  private val TASK_ID: String  = "id"
+  private val TIMESTAMP: String = "ts"
+  private val JOB_NAME: String = "job_name"
+  private val JOB_OWNER: String = "job_owner"
+  private val JOB_SCHEDULE: String = "job_schedule"
+  private val JOB_PARENTS: String = "job_parents"
+  private val TASK_STATE: String = "task_state"
+  private val SLAVE_ID: String = "slave_id"
+  private val MESSAGE: String = "message"
+  private val ATTEMPT: String = "attempt"
+  private val IS_FAILURE: String = "is_failure"
+
+  protected val jobStates = new HashMap[String, CurrentState.Value]()
 
   val log = Logger.getLogger(getClass.getName)
   val statements = new ConcurrentHashMap[String, PreparedStatement]().asScala
   var _session: Option[Session] = None
 
-  def jobStarted(job: BaseJob, taskStatus: TaskStatus, attempt: Int) {
-    try {
-      getSession match {
-        case Some(session: Session) =>
-          job match {
-            case job: ScheduleBasedJob =>
-              val query =
-                s"INSERT INTO ${config.cassandraTable()} (id, ts, job_name, job_owner, job_schedule, task_state, slave_id, attempt) VALUES (?, ?, ?, ?, ?, ?, ?, ?) USING TTL ${config.cassandraTtl()}"
-              val prepared = statements.getOrElseUpdate(query, {
-                session.prepare(
-                  new SimpleStatement(query).setConsistencyLevel(ConsistencyLevel.valueOf(config.cassandraConsistency())).asInstanceOf[RegularStatement]
-                )
-              })
-              session.executeAsync(prepared.bind(
-                taskStatus.getTaskId.getValue,
-                new java.util.Date(),
-                job.name,
-                job.owner,
-                job.schedule,
-                taskStatus.getState.toString,
-                taskStatus.getSlaveId.getValue,
-                attempt: java.lang.Integer
-              ))
-            case job: DependencyBasedJob =>
-              val query =
-                s"INSERT INTO ${config.cassandraTable()} (id, ts, job_name, job_owner, job_parents, task_state, slave_id, attempt) VALUES (?, ?, ?, ?, ?, ?, ?, ?) USING TTL ${config.cassandraTtl()}"
-              val prepared = statements.getOrElseUpdate(query, {
-                session.prepare(
-                  new SimpleStatement(query).setConsistencyLevel(ConsistencyLevel.valueOf(config.cassandraConsistency())).asInstanceOf[RegularStatement]
-                )
-              })
-              val parentSet: java.util.Set[String] = job.parents.asJava
-              session.executeAsync(prepared.bind(
-                taskStatus.getTaskId.getValue,
-                new java.util.Date(),
-                job.name,
-                job.owner,
-                parentSet,
-                taskStatus.getState.toString,
-                taskStatus.getSlaveId.getValue,
-                attempt: java.lang.Integer
-              ))
-          }
-        case None =>
-      }
-    } catch {
-      case e: NoHostAvailableException =>
-        resetSession()
-        log.log(Level.WARNING, "No hosts were available, will retry next time.", e)
-      case e: QueryExecutionException =>
-        log.log(Level.WARNING, "Query execution failed:", e)
-      case e: QueryValidationException =>
-        log.log(Level.WARNING, "Query validation failed:", e)
+  def getJobState(jobName: String) : CurrentState.Value = {
+    /**
+     * NOTE: currently everything stored in memory, look into moving
+     * this to Cassandra. ZK is not an option cause serializers and
+     * deserializers need to be written. Need a good solution, potentially
+     * lots of writes and very few reads (only on failover)
+     */
+    val status = jobStates.get(jobName) match {
+      case Some(s) =>
+        s
+      case _ =>
+        CurrentState.idle
     }
+    status
+  }
+
+  def updateJobState(jobName: String, state: CurrentState.Value) {
+    var shouldUpdate = true
+    jobStates.get(jobName) match {
+      case Some(s: CurrentState.Value) => {
+        if ((s == CurrentState.running) &&
+            (state == CurrentState.queued)) {
+          //don't update status if already running
+          shouldUpdate = false
+        }
+      }
+      case None =>
+    }
+
+    if (shouldUpdate) {
+      log.info("Updating state for job (%s) to %s".format(jobName, state))
+      jobStates.put(jobName, state)
+    }
+  }
+
+  def removeJobState(job: BaseJob) {
+    jobStates.remove(job.name)
+  }
+
+  def jobQueued(job: BaseJob, attempt: Int) {
+    updateJobState(job.name, CurrentState.queued)
+  }
+
+  def jobStarted(job: BaseJob, taskStatus: TaskStatus, attempt: Int) {
+    updateJobState(job.name, CurrentState.running)
+
+    var jobSchedule:Option[String] = None
+    var jobParents:Option[java.util.Set[String]] = None
+    job match {
+      case job: ScheduleBasedJob =>
+        jobSchedule = Some(job.schedule)
+      case job: DependencyBasedJob =>
+        jobParents = Some(job.parents.asJava)
+    }
+    insertToStatTable(
+            id=Some(taskStatus.getTaskId.getValue),
+            timestamp=Some(new java.util.Date()),
+            jobName=Some(job.name),
+            jobOwner=Some(job.owner),
+            jobSchedule=jobSchedule,
+            jobParents=jobParents,
+            taskState=Some(taskStatus.getState.toString),
+            slaveId=Some(taskStatus.getSlaveId.getValue),
+            message=None,
+            attempt=Some(attempt),
+            isFailure=None)
   }
 
   def getSession: Option[Session] = {
@@ -124,106 +160,143 @@ class JobStats @Inject()(clusterBuilder: Option[Cluster.Builder], config: Cassan
   }
 
   def jobFinished(job: BaseJob, taskStatus: TaskStatus, attempt: Int) {
-    try {
-      getSession match {
-        case Some(session: Session) =>
-          job match {
-            case job: ScheduleBasedJob =>
-              val query =
-                s"INSERT INTO ${config.cassandraTable()} (id, ts, job_name, job_owner, job_schedule, task_state, slave_id, attempt) VALUES (?, ?, ?, ?, ?, ?, ?, ?) USING TTL ${config.cassandraTtl()}"
-              val prepared = statements.getOrElseUpdate(query, {
-                session.prepare(
-                  new SimpleStatement(query).setConsistencyLevel(ConsistencyLevel.valueOf(config.cassandraConsistency())).asInstanceOf[RegularStatement]
-                )
-              })
-              session.executeAsync(prepared.bind(
-                taskStatus.getTaskId.getValue,
-                new java.util.Date(),
-                job.name,
-                job.owner,
-                job.schedule,
-                taskStatus.getState.toString,
-                taskStatus.getSlaveId.getValue,
-                attempt: java.lang.Integer
-              ))
-            case job: DependencyBasedJob =>
-              val query =
-                s"INSERT INTO ${config.cassandraTable()} (id, ts, job_name, job_owner, job_parents, task_state, slave_id, attempt) VALUES (?, ?, ?, ?, ?, ?, ?, ?) USING TTL ${config.cassandraTtl()}"
-              val prepared = statements.getOrElseUpdate(query, {
-                session.prepare(
-                  new SimpleStatement(query).setConsistencyLevel(ConsistencyLevel.valueOf(config.cassandraConsistency())).asInstanceOf[RegularStatement]
-                )
-              })
-              val parentSet: java.util.Set[String] = job.parents.asJava
-              session.execute(prepared.bind(
-                taskStatus.getTaskId.getValue,
-                new java.util.Date(),
-                job.name,
-                job.owner,
-                parentSet,
-                taskStatus.getState.toString,
-                taskStatus.getSlaveId.getValue,
-                attempt: java.lang.Integer
-              ))
-          }
-        case None =>
-      }
-    } catch {
-      case e: NoHostAvailableException =>
-        resetSession()
-        log.log(Level.WARNING, "No hosts were available, will retry next time.", e)
-      case e: QueryExecutionException =>
-        log.log(Level.WARNING, "Query execution failed:", e)
-      case e: QueryValidationException =>
-        log.log(Level.WARNING, "Query validation failed:", e)
+    updateJobState(job.name, CurrentState.idle)
+
+    var jobSchedule:Option[String] = None
+    var jobParents:Option[java.util.Set[String]] = None
+    job match {
+      case job: ScheduleBasedJob =>
+        jobSchedule = Some(job.schedule)
+      case job: DependencyBasedJob =>
+        jobParents = Some(job.parents.asJava)
     }
+    insertToStatTable(
+            id=Some(taskStatus.getTaskId.getValue),
+            timestamp=Some(new java.util.Date()),
+            jobName=Some(job.name),
+            jobOwner=Some(job.owner),
+            jobSchedule=jobSchedule,
+            jobParents=jobParents,
+            taskState=Some(taskStatus.getState.toString),
+            slaveId=Some(taskStatus.getSlaveId.getValue),
+            message=None,
+            attempt=Some(attempt),
+            isFailure=None)
   }
 
   def jobFailed(job: BaseJob, taskStatus: TaskStatus, attempt: Int) {
+    updateJobState(job.name, CurrentState.idle)
+
+    var jobSchedule:Option[String] = None
+    var jobParents:Option[java.util.Set[String]] = None
+    job match {
+      case job: ScheduleBasedJob =>
+        jobSchedule = Some(job.schedule)
+      case job: DependencyBasedJob =>
+        jobParents = Some(job.parents.asJava)
+    }
+    insertToStatTable(
+            id=Some(taskStatus.getTaskId.getValue),
+            timestamp=Some(new java.util.Date()),
+            jobName=Some(job.name),
+            jobOwner=Some(job.owner),
+            jobSchedule=jobSchedule,
+            jobParents=jobParents,
+            taskState=Some(taskStatus.getState.toString),
+            slaveId=Some(taskStatus.getSlaveId.getValue),
+            message=Some(taskStatus.getMessage),
+            attempt=Some(attempt),
+            isFailure=Some(true))
+  }
+
+  /**
+   * Overloaded method of jobFailed. Reports that a job identified by only
+   * its job name failed during execution. This is only used to report
+   * a failure when there is no corresponding job object, which only happens
+   * when a job is destroyed. When a job is destroyed, all tasks are killed
+   * and this method is called when a task is killed.
+   * @param jobName
+   * @param taskStatus
+   * @param attempt
+   */
+  def jobFailed(jobName: String, taskStatus: TaskStatus, attempt: Int) {
+    updateJobState(jobName, CurrentState.idle)
+
+    insertToStatTable(
+        id=Some(taskStatus.getTaskId.getValue),
+        timestamp=Some(new java.util.Date()),
+        jobName=Some(jobName),
+        jobOwner=None, jobSchedule=None, jobParents=None,
+        taskState=Some(taskStatus.getState().toString()),
+        slaveId=Some(taskStatus.getSlaveId().getValue()),
+        message=Some(taskStatus.getMessage()),
+        attempt=Some(attempt),
+        isFailure=Some(true))
+  }
+
+  /**
+   * Helper method that performs an insert statement to update the
+   * job statistics (chronos) table. All arguments are surrounded
+   * by options so that a subset of values can be inserted.
+   */
+  private def insertToStatTable(id: Option[String],
+      timestamp: Option[java.util.Date],
+      jobName: Option[String],
+      jobOwner: Option[String],
+      jobSchedule: Option[String],
+      jobParents: Option[java.util.Set[String]],
+      taskState: Option[String],
+      slaveId: Option[String],
+      message: Option[String],
+      attempt: Option[Integer],
+      isFailure: Option[Boolean]) = {
     try {
       getSession match {
         case Some(session: Session) =>
-          job match {
-            case job: ScheduleBasedJob =>
-              val query =
-                s"INSERT INTO ${config.cassandraTable()} (id, ts, job_name, job_owner, job_schedule, task_state, slave_id, attempt, message, is_failure) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, true) USING TTL ${config.cassandraTtl()}"
-              val prepared = statements.getOrElseUpdate(query, {
-                session.prepare(
-                  new SimpleStatement(query).setConsistencyLevel(ConsistencyLevel.valueOf(config.cassandraConsistency())).asInstanceOf[RegularStatement]
-                )
-              })
-              session.executeAsync(prepared.bind(
-                taskStatus.getTaskId.getValue,
-                new java.util.Date(),
-                job.name,
-                job.owner,
-                job.schedule,
-                taskStatus.getState.toString,
-                taskStatus.getSlaveId.getValue,
-                attempt: java.lang.Integer,
-                taskStatus.getMessage
-              ))
-            case job: DependencyBasedJob =>
-              val query =
-                s"INSERT INTO ${config.cassandraTable} (id, ts, job_name, job_owner, job_parents, task_state, slave_id, attempt, message, is_failure) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, true) USING TTL ${config.cassandraTtl()}"
-              val prepared = statements.getOrElseUpdate(query, {
-                session.prepare(
-                  new SimpleStatement(query).setConsistencyLevel(ConsistencyLevel.valueOf(config.cassandraConsistency())).asInstanceOf[RegularStatement]
-                )
-              })
-              val parentSet: java.util.Set[String] = job.parents.asJava
-              session.executeAsync(prepared.bind(
-                taskStatus.getTaskId.getValue,
-                new java.util.Date(),
-                job.name,
-                job.owner,
-                parentSet,
-                taskStatus.getState.toString,
-                taskStatus.getSlaveId.getValue,
-                attempt: java.lang.Integer,
-                taskStatus.getMessage
-              ))
+          var query:Insert = QueryBuilder.insertInto(config.cassandraTable())
+
+          //set required values (let these throw an exception)
+          query.value(TASK_ID , id.get)
+            .value(JOB_NAME , jobName.get)
+            .value(TIMESTAMP , timestamp.get)
+
+          jobOwner match {
+            case Some(jo: String) => query.value(JOB_OWNER , jo)
+            case _ =>
           }
+          jobSchedule match {
+            case Some(js: String) => query.value(JOB_SCHEDULE , js)
+            case _ =>
+          }
+          jobParents match {
+            case Some(jp: java.util.Set[String]) => query.value(JOB_PARENTS , jp)
+            case _ =>
+          }
+          taskState match {
+            case Some(ts: String) => query.value(TASK_STATE , ts)
+            case _ =>
+          }
+          slaveId match {
+            case Some(s: String) => query.value(SLAVE_ID , s)
+            case _ =>
+          }
+          message match {
+            case Some(m: String) => query.value(MESSAGE , m)
+            case _ =>
+          }
+          attempt match {
+            case Some(a: Integer) => query.value(ATTEMPT , a)
+            case _ =>
+          }
+          isFailure match {
+            case Some(f: Boolean) => query.value(IS_FAILURE , f)
+            case _ =>
+          }
+
+          query.setConsistencyLevel(ConsistencyLevel.valueOf(config.cassandraConsistency()))
+            .asInstanceOf[RegularStatement]
+
+          session.executeAsync(query)
         case None =>
       }
     } catch {
@@ -231,9 +304,10 @@ class JobStats @Inject()(clusterBuilder: Option[Cluster.Builder], config: Cassan
         resetSession()
         log.log(Level.WARNING, "No hosts were available, will retry next time.", e)
       case e: QueryExecutionException =>
-        log.log(Level.WARNING, "Query execution failed:", e)
+        log.log(Level.WARNING,"Query execution failed: ", e)
       case e: QueryValidationException =>
-        log.log(Level.WARNING, "Query validation failed:", e)
+        log.log(Level.WARNING,"Query validation failed: ", e)
     }
+
   }
 }

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/graph/Exporter.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/graph/Exporter.scala
@@ -3,6 +3,7 @@ package org.apache.mesos.chronos.scheduler.jobs.graph
 import java.io._
 
 import org.apache.mesos.chronos.scheduler.graph.JobGraph
+import org.apache.mesos.chronos.scheduler.jobs.JobScheduler
 import org.apache.mesos.chronos.scheduler.jobs.BaseJob
 import org.jgrapht.graph.DefaultEdge
 import org.joda.time.DateTime
@@ -15,12 +16,12 @@ import scala.collection.mutable.HashMap
  */
 object Exporter {
 
-  def export(w: Writer, jobGraph: JobGraph) {
+  def export(w: Writer, jobGraph: JobGraph, jobScheduler: JobScheduler) {
     val dag = jobGraph.dag
     val jobMap = new mutable.HashMap[String, BaseJob]
     import scala.collection.JavaConversions._
     dag.vertexSet.flatMap(jobGraph.lookupVertex).foreach(x => jobMap.put(x.name, x))
-    jobMap.foreach({ case (k, v) => w.write("node,%s,%s\n".format(k, getLastState(v).toString))})
+    jobMap.foreach({ case (k, v) => w.write("node,%s,%s,%s\n".format(k,getLastState(v).toString,jobScheduler.jobStats.getJobState(k).toString()))})
     for (e: DefaultEdge <- dag.edgeSet) {
       val source = dag.getEdgeSource(e)
       val target = dag.getEdgeTarget(e)

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
@@ -215,6 +215,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
         scheduler.handleFailedTask(taskStatus)
       case TaskState.TASK_RUNNING =>
         log.info("Task with id '%s' RUNNING.".format(taskStatus.getTaskId.getValue))
+      case TaskState.TASK_KILLED =>
+        log.info("Task with id '%s' KILLED.".format(taskStatus.getTaskId.getValue))
+        scheduler.handleKilledTask(taskStatus)
       case _ =>
         log.warning("Unknown TaskState:" + taskStatus.getState + " for task: " + taskStatus.getTaskId.getValue)
     }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManagerSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManagerSpec.scala
@@ -13,7 +13,7 @@ class TaskManagerSpec extends SpecificationWithJUnit with Mockito {
   "TaskManager" should {
     "Calculate the correct time delay between scheduling and dispatching the job" in {
       val taskManager = new TaskManager(mock[ListeningScheduledExecutorService], mock[PersistenceStore],
-        mock[JobGraph], null, mock[MetricRegistry])
+        mock[JobGraph], null, mock[JobStats], mock[MetricRegistry])
       val millis = taskManager.getMillisUntilExecution(new DateTime(DateTimeZone.UTC).plus(Hours.ONE))
       val expectedSeconds = scala.math.round(Period.hours(1).toStandardDuration.getMillis / 1000d)
       //Due to startup time / JVM overhead, millis wouldn't be totally accurate.


### PR DESCRIPTION
..., everything is stored in memory. Look into persisting this state onto Cassandra.