### PR TITLE
REST endpoint to retrieve job status

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Also join us on IRC in #mesos on freenode.
 * [API](#api)
     - [Leader](#leaders)
     - [Listing Jobs](#listing-jobs)
+    - [Retrieving a Job status](#retrieving-a-job-status)
     - [Deleting a Job](#deleting-a-job)
     - [Deleting All Tasks for a Job](#deleting-all-tasks-for-a-job)
     - [Manually Starting a Job](#manually-starting-a-job)
@@ -153,6 +154,16 @@ Interesting fields in the hashes are:
 * `parents`: for dependent jobs, a list of all other jobs that must run before this job will do so
 
 If there is a `parents` field there will be no `schedule` field and vice-versa.
+
+### Retriving a Job status
+
+* Endpoint: __/scheduler/job/status/jobName__
+* Method: __GET__
+* Example: `curl -L -X GET chronos-node:8080/scheduler/job/status/request_event_counter_hourly`
+* Response: JSON data
+
+Retrieving a job status returns a JSON object containing fields `job_name` and `status`.
+Valid values for `status` are "NOT RUN", "RUNNING", "FAILURE" and "SUCCESS".
 
 ### Deleting a Job
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Interesting fields in the hashes are:
 
 If there is a `parents` field there will be no `schedule` field and vice-versa.
 
-### Retriving a Job status
+### Retrieving a Job status
 
 * Endpoint: __/scheduler/job/status/jobName__
 * Method: __GET__

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
@@ -246,7 +246,7 @@ class JobManagementResource @Inject()(val jobScheduler: JobScheduler,
           status = "FAILURE"
         } else if (!lastSuccess.equals(lastError)) {
           // Compare timestamps
-          status = if (lastSuccess.toLower > lastError.toLower) "SUCCESS" else "FAILED"
+          status = if (lastSuccess.toLowerCase > lastError.toLowerCase) "SUCCESS" else "FAILED"
         }
       }
 

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
@@ -236,8 +236,8 @@ class JobManagementResource @Inject()(val jobScheduler: JobScheduler,
           case TaskState.TASK_FAILED | TaskState.TASK_KILLED | TaskState.TASK_LOST => status = "FAILED"
           case TaskState.TASK_FINISHED => status = "SUCCESS"
           case TaskState.TASK_RUNNING | TaskState.TASK_STAGING | TaskState.TASK_STARTING => status = "RUNNING"
-          case _ =>
-            log.error("Could not figure out task state for value " + String.valueOf(_))
+          case default =>
+            log.log(Level.WARNING, "Could not figure out task state for value " + default)
             throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
         }
       } else {

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/PathConstants.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/PathConstants.scala
@@ -18,6 +18,7 @@ object PathConstants {
   final val jobGraphDotPath = "dot"
   final val jobGraphCsvPath = "csv"
   final val killTaskPattern = "kill/{jobName}"
+  final val jobStatusPath = "job/status/{jobName}"
 
   final val isMasterPath = "isMaster"
   final val taskBasePath = "/task"

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
@@ -1,5 +1,6 @@
 package org.apache.mesos.chronos.scheduler.jobs
 
+import java.util
 import java.util.concurrent.{ConcurrentHashMap, Future, TimeUnit}
 import java.util.logging.Logger
 
@@ -216,5 +217,19 @@ class TaskManager @Inject()(val listeningExecutor: ListeningScheduledExecutorSer
     persistenceStore.getTaskIds(Some(baseJob.name)).foreach({ x =>
       persistenceStore.removeTask(x)
     })
+  }
+
+  /**
+   * Returns all TaskStates for given job.
+   * @param job
+   * @return
+   */
+  def getMesosTaskStates(job: BaseJob) : List[TaskState] = {
+    import scala.collection.JavaConversions._
+    val (_, values) = taskCache.asMap
+      .filterKeys(TaskUtils.getJobNameForTaskId(_) == job.name)
+      .toList
+      .sortWith((a,b) => a._1.toLowerCase > b._1.toLowerCase).unzip
+    values
   }
 }

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
@@ -220,16 +220,20 @@ class TaskManager @Inject()(val listeningExecutor: ListeningScheduledExecutorSer
   }
 
   /**
-   * Returns all TaskStates for given job.
+   * Returns all TaskStates in order for given job.
    * @param job
    * @return
    */
   def getMesosTaskStates(job: BaseJob) : List[TaskState] = {
     import scala.collection.JavaConversions._
+    // Filter out job that do not match job name,
+    // sort tuple by timestamp as it is most defining element in key
+    // and finally extract tuples to two separate lists
     val (_, values) = taskCache.asMap
       .filterKeys(TaskUtils.getJobNameForTaskId(_) == job.name)
       .toList
-      .sortWith((a,b) => a._1.toLowerCase > b._1.toLowerCase).unzip
+      .sortWith((a,b) => a._1.toLowerCase > b._1.toLowerCase)
+      .unzip
     values
   }
 }


### PR DESCRIPTION
The company that I work for uses Chronos to schedule pipelines and we needed an ability to get task status similarly as Mesos shows them; namely needed the ability see when job is running. I've created a new REST endpoint to retrieve this information as I didn't dare to update job related endpoints because I was quite sure if that could have broken something, at least is would have changed the entity content.

Feel free to ignore this pull request if you think your project does not need this.

Best regards,

Mikko Kupsu