### PR TITLE
Enhance sync script to allow for unprompted delete of missing jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,9 +454,14 @@ to live.
 
 Note: `chronos-sync.rb` does not delete jobs by default. You can pass the `--delete-missing` flag to `chronos-sync.rb` to remove jobs. Alternatively, you can manually remove it using the API or web UI.
 
-## Debugging Chronos Jobs
+## Debugging
 
-Chronos itself can be configured just like [dropwizard-logging][logging] via the configuration file. If there's something going wrong with the framework itself look here for information. Individual jobs log with their task id on the mesos slaves.
+### Debugging Chronos
+
+Chronos uses log4j to control log output.  To override the standard log4j configuration, create a [log4j configuration file](http://logging.apache.org/log4j/1.2/manual.html) and add `-Dlog4j.configuration=file:<path to config>` to the Chronos startup command. 
+
+### Debugging Jobs
+Individual jobs log with their task id on the mesos slaves.
 Look in the standard out log for your job name and the string "ready for launch", or else "job ct:" and your job name.
 The job is done when the line in the log says:
 

--- a/bin/chronos-sync.rb
+++ b/bin/chronos-sync.rb
@@ -16,6 +16,7 @@ options.update_from_chronos = false
 options.force = false
 options.validate = false
 options.delete_missing = false
+options.no_prompt_for_delete = false
 options.skip_sync = false
 
 opts = OptionParser.new do |o|
@@ -43,8 +44,11 @@ opts = OptionParser.new do |o|
     options.http_auth_user = cred_split[0].strip
     options.http_auth_pass = cred_split[1].strip
   end
-  o.on("--delete-missing", "Prompt to delete missing jobs") do
+  o.on("--delete-missing", "Delete missing jobs from chronos. Prompts for confirmation") do
     options.delete_missing = true
+  end
+  o.on("--no-prompt-for-delete", "Do not prompt for deletion of missing jobs") do
+    options.no_prompt_for_delete = true
   end
   o.on("--skip-sync", "Skip syncing local jobs") do
     options.skip_sync = true
@@ -459,8 +463,9 @@ end
 def check_if_defined(jobs, name, options)
   if !jobs.include?(name)
     if options.delete_missing
-      $stdout.print "The job #{name} exists in chronos, but is not defined! Delete [yN]? "
-      delete_job(options, name) if $stdin.gets.chomp.downcase == "y"
+      $stdout.print "The job #{name} exists in chronos, but is not defined! "
+      $stdout.print "Delete [yN]? " unless options.no_prompt_for_delete
+      delete_job(options, name) if (options.no_prompt_for_delete || $stdin.gets.chomp.downcase == "y")
     else
       $stderr.puts "The job #{name} exists in chronos, but is not defined!"
     end


### PR DESCRIPTION
We have an automated script to sync our chronos jobs from our master task list.  In this use case, we don't want to be prompted to delete missing jobs since our job source is always the source of record.  