### PR TITLE
Updating Slack integration to comply with new Slack webhook format

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/notification/SlackClient.scala
+++ b/src/main/scala/org/apache/mesos/chronos/notification/SlackClient.scala
@@ -7,9 +7,7 @@ import java.util.logging.Logger
 import org.apache.mesos.chronos.scheduler.jobs.BaseJob
 import com.fasterxml.jackson.core.JsonFactory
 
-class SlackClient(val webhookUrl: String,
-                  val token: String,
-                  val channel: String) extends NotificationClient {
+class SlackClient(val webhookUrl: String) extends NotificationClient {
 
   private[this] val log = Logger.getLogger(getClass.getName)
 
@@ -21,7 +19,6 @@ class SlackClient(val webhookUrl: String,
 
     // Create the payload
     generator.writeStartObject()
-    generator.writeStringField("channel", channel)
 
     if (message.nonEmpty && message.get.nonEmpty) {
       generator.writeStringField("text", message.get)
@@ -34,7 +31,7 @@ class SlackClient(val webhookUrl: String,
 
     var connection: HttpURLConnection = null
     try {
-      val url = new URL(webhookUrl + "?token=" + token)
+      val url = new URL(webhookUrl)
       connection = url.openConnection.asInstanceOf[HttpURLConnection]
       connection.setDoInput(true)
       connection.setDoOutput(true)

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/config/MainModule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/config/MainModule.scala
@@ -133,10 +133,8 @@ class MainModule(val config: SchedulerConfiguration with HttpConf)
       },
       for {
         webhookUrl <- config.slackWebhookUrl.get if !config.slackWebhookUrl.isEmpty
-        token <- config.slackToken.get if !config.slackToken.isEmpty
-        channel <- config.slackChannel.get if !config.slackChannel.isEmpty
       } yield {
-        create(classOf[SlackClient], webhookUrl, token, channel)
+        create(classOf[SlackClient], webhookUrl)
       }
     ).flatten
   }

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/config/SchedulerConfiguration.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/config/SchedulerConfiguration.scala
@@ -70,12 +70,6 @@ trait SchedulerConfiguration extends ScallopConf {
   lazy val slackWebhookUrl = opt[String]("slack_url",
     descr = "Webhook URL for posting to Slack",
     default = None)
-  lazy val slackToken = opt[String]("slack_token",
-    descr = "Token needed for posting to Slack",
-    default = None)
-  lazy val slackChannel = opt[String]("slack_channel",
-    descr = "The channel to post to in Slack",
-    default = None)
   lazy val failureRetryDelayMs = opt[Long]("failure_retry",
     descr = "Number of ms between retries",
     default = Some(60000))


### PR DESCRIPTION
Slack has changed their web hook format, this update makes the Slack integration work again. 