### PR TITLE
Adding subject to Slack notification

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/notification/SlackClient.scala
+++ b/src/main/scala/org/apache/mesos/chronos/notification/SlackClient.scala
@@ -19,9 +19,13 @@ class SlackClient(val webhookUrl: String) extends NotificationClient {
 
     // Create the payload
     generator.writeStartObject()
-
+    
     if (message.nonEmpty && message.get.nonEmpty) {
-      generator.writeStringField("text", message.get)
+      if (subject != null && subject.nonEmpty) {
+        generator.writeStringField("text", "%s: %s".format(subject, message.get))
+      } else {
+        generator.writeStringField("text", "%s".format(message.get))
+      }
     }
 
     generator.writeEndObject()


### PR DESCRIPTION
Whoops - should have added this in the last PR.  Having the subject in the slack notification helps distinguish what environment the alert is coming from. 