### PR TITLE
Remove chronos-sync skip logic

### DIFF
--- a/bin/chronos-sync.rb
+++ b/bin/chronos-sync.rb
@@ -302,16 +302,6 @@ if !options.skip_sync
           end
         end
         if options.force || !scheduled_jobs.include?(name) || normalize_job(existing_job).to_a.sort_by{|x|x[0]} != normalize_job(new_job).to_a.sort_by{|x|x[0]}
-          # Check if scheduled start time is in the past
-          start_time = DateTime.iso8601(/^R\d*\/([^\/]+)\//.match(new_schedule)[1])
-          if start_time < cur_datetime
-            split_schedule = new_schedule.split(/\//)
-            # Reset start time to the next available
-            new_start_time = start_time + (cur_datetime - start_time).to_f.ceil
-            new_new_schedule = [split_schedule[0], new_start_time.iso8601(3), split_schedule[2]].join('/')
-            puts "Schedule for '#{new_job['name']}' begins in the past!  Resetting to from #{new_schedule} to #{new_new_schedule}"
-            new_schedule = new_new_schedule
-          end
           new_job['schedule'] = new_schedule
           jobs_to_be_updated << {
             :new => job,


### PR DESCRIPTION
The chronos-sync.rb script currently has logic in it to skip jobs ahead if they have a schedule in the past.  However, this logic is broken for irregular intervals (P1M, for example).  As you can see below, it incorrectly sets the new date to 2015-04-02 instead of 2015-04-01. 

    Schedule for 'build_gas_stubs' begins in the past!  Resetting to from R/2014-09-01T11:05:00-04:00/P1M to R/2015-04-02T11:05:00.000-04:00/P1M

Chronos itself already has logic to do this (in JobUtils.makeScheduleStream), so I'm not sure if it's still necessary to do so in the sync script. 