### PR TITLE
Chronos Credential Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Also join us on IRC in #mesos on freenode.
     - [Job Configuration](#job-configuration)
     - [Sample Job](#sample-job)
 * [Job Management](#job-management)
+* [Mesos Framework Authentication](#mesos-framework-authentication)
 * [Debugging Chronos](#debugging-chronos)
 * [Debugging Individual Jobs](#debugging-individual-jobs)
 * [Notes](#notes)
@@ -461,6 +462,30 @@ passing the `-f` or `--force` parameter.  In the example above,
 to live.
 
 Note: `chronos-sync.rb` does not delete jobs by default. You can pass the `--delete-missing` flag to `chronos-sync.rb` to remove jobs. Alternatively, you can manually remove it using the API or web UI.
+
+## Mesos Framework Authentication
+
+To enable framework authentication in Chronos:
+
+* Run Chronos with `--mesos_authentication_principal` set to a Mesos-authorized principal. For Mesos' built-in CRAM-MD5 authentication, you must also provide `--mesos_authentication_secret_file` pointing to a file containing your authentication secret.
+
+> The secret file cannot have a trailing newline. To not add a newline simply run:
+```bash
+$ echo -n "secret" > /path/to/secret/file
+```
+
+* If using the built-in CRAM-MD5 authentication mechanism, run mesos-master with the credentials flag and the path to the file with authorized users and their secrets.
+```bash
+--credentials=/path/to/credential/file
+```
+
+> Note that this `--credentials` file is for all frameworks and slaves registering with Mesos. In enterprise installations, the cluster admin will have already configured credentials in Mesos, so the user launching Chronos just needs to specify the principal+secret given to them by the cluster/security admin 
+> Each line in the file should be a principal and corresponding secret separated by a single space.
+```bash
+$ cat /path/to/credential/file
+principal secret
+principal2 secret2
+```
 
 ## Debugging
 

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/config/MainModule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/config/MainModule.scala
@@ -59,6 +59,8 @@ class MainModule(val config: SchedulerConfiguration with HttpConf)
       .setFailoverTimeout(config.failoverTimeoutSeconds())
       .setUser(config.user())
 
+    config.mesosAuthenticationPrincipal.get.foreach(frameworkInfoBuilder.setPrincipal)
+
     if (config.webuiUrl.isSupplied) {
       frameworkInfoBuilder.setWebuiUrl(config.webuiUrl())
     } else if (config.sslKeystorePath.isDefined) {

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/config/SchedulerConfiguration.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/config/SchedulerConfiguration.scala
@@ -107,6 +107,13 @@ trait SchedulerConfiguration extends ScallopConf {
   lazy val reconciliationInterval = opt[Int]("reconciliation_interval",
     descr = "Reconciliation interval in seconds",
     default = Some(600))
+  lazy val mesosAuthenticationPrincipal = opt[String]("mesos_authentication_principal",
+    descr = "Mesos Authentication Principal",
+    noshort = true)
+  lazy val mesosAuthenticationSecretFile = opt[String]("mesos_authentication_secret_file",
+    descr = "Mesos Authentication Secret",
+    noshort = true)
+
 
   def zooKeeperHostAddresses: Seq[InetSocketAddress] =
     for (s <- zookeeperServers().split(",")) yield {

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosDriverFactory.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosDriverFactory.scala
@@ -3,8 +3,13 @@ package org.apache.mesos.chronos.scheduler.mesos
 import java.util.logging.Logger
 
 import org.apache.mesos.chronos.scheduler.config.SchedulerConfiguration
-import org.apache.mesos.Protos.{FrameworkInfo, Status}
+import org.apache.mesos.Protos.{Credential, FrameworkInfo, Status}
 import org.apache.mesos.{MesosSchedulerDriver, Scheduler}
+import com.google.protobuf.ByteString
+import java.io.{File, FileInputStream, IOException}
+import java.nio.file.{Files, Paths}
+import java.nio.file.attribute.{PosixFilePermission, PosixFilePermissions}
+import scala.collection.JavaConverters.asScalaSetConverter
 
 /**
  * The chronos driver doesn't allow calling the start() method after stop() has been called, thus we need a factory to
@@ -33,7 +38,16 @@ class MesosDriverFactory(val mesosScheduler: Scheduler, val frameworkInfo: Frame
   }
 
   def makeDriver() {
-    mesosDriver = Some(new MesosSchedulerDriver(mesosScheduler, frameworkInfo, config.master()))
+
+    val driver = config.mesosAuthenticationPrincipal.get match {
+      case Some(principal) =>
+        val credential = buildMesosCredentials(principal, config.mesosAuthenticationSecretFile.get)
+        new MesosSchedulerDriver(mesosScheduler, frameworkInfo, config.master(), credential)
+      case None =>
+        new MesosSchedulerDriver(mesosScheduler, frameworkInfo, config.master())
+    }
+
+    mesosDriver = Option(driver)
   }
 
   def close() {
@@ -45,4 +59,34 @@ class MesosDriverFactory(val mesosScheduler: Scheduler, val frameworkInfo: Frame
     mesosDriver.get.stop(true)
     mesosDriver = None
   }
+
+
+  /**
+   * Create the optional credentials instance, used to authenticate calls from Chronos to Mesos.
+   */
+  def buildMesosCredentials(principal: String, secretFile: Option[String]): Credential = {
+
+    val credentialBuilder = Credential.newBuilder()
+      .setPrincipal(principal)
+
+    secretFile foreach { file =>
+      try {
+        val secretBytes = ByteString.readFrom(new FileInputStream(file))
+
+        val filePermissions = Files.getPosixFilePermissions(Paths.get(file)).asScala
+        if (!(filePermissions & Set(PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_WRITE)).isEmpty)
+          log.warning(s"Secret file $file should not be globally accessible.")
+
+        credentialBuilder.setSecret(secretBytes)
+      }
+      catch {
+        case cause: Throwable =>
+          throw new IOException(s"Error reading authentication secret from file [$file]", cause)
+      }
+    }
+
+    credentialBuilder.build()
+  }
+
+
 }

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
@@ -257,8 +257,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
   @Override
   def error(schedulerDriver: SchedulerDriver, message: String) {
-    log.info("Error: " + message)
+    log.severe(message)
     scheduler.shutDown()
+    System.exit(1)
   }
 
   private def logOffer(offer: Offer) {


### PR DESCRIPTION
To use the credentials in chronos:

* Run mesos-master with the credentials flag and the path to file with authorized users + their secrets. 
`--credentials=/path/to/credential/file`

> Each line in the file should be a principal space separated with their password. 
```bash
$ cat /path/to/credential/file
principal secret
principal2 secret2
```

* Run chronos with the `--mesos_authentication_principal` flag and optionally with the   
`--mesos_authentication_secret_file` flag that contains the secret.

> The secret file cannot have a trailing newline. To not add a newline simply run:
```bash
$ echo -n "secret" > /path/to/secret/file
```