### PR TITLE
Add constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ you can also use a url in the command field, if your mesos was compiled with cUR
 | container           | This contains the subfields for the container, type (req), image (req), network (optional) and volumes (optional).          | -                              |
 | dataJob             | Toggles whether the job tracks data (number of elements processed)                                       | `false`                        |
 | environmentVariables| An array of environment variables passed to the Mesos executor. For Docker containers, these are also passed to Docker using the -e flag. | -                              |
+| constraints         | Control where jobs run. Each constraint is compared against the [attributes of a Mesos slave](http://mesos.apache.org/documentation/attributes-resources/). See [Constraints](#constraints). | - |
 
 ### Sample Job
 
@@ -456,6 +457,18 @@ you can also use a url in the command field, if your mesos was compiled with cUR
      {"name": "JAVA_LIBRARY_PATH", "value": "/usr/local/lib"}
    ]
 }
+```
+
+## Constraints
+
+### EQUALS constraint
+
+Schedule a job on nodes that share a common attribute.
+
+```json
+...
+"constraints": [["rack", "EQUALS", "rack-1"]],
+...
 ```
 
 ## Job Management

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Jobs.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Jobs.scala
@@ -1,5 +1,6 @@
 package org.apache.mesos.chronos.scheduler.jobs
 
+import org.apache.mesos.chronos.scheduler.jobs.constraints.Constraint
 import org.apache.mesos.chronos.utils.JobDeserializer
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
@@ -77,6 +78,8 @@ trait BaseJob {
   def softError: Boolean = false
 
   def dataProcessingJobType: Boolean = false
+
+  def constraints: Seq[Constraint] = List()
 }
 
 @JsonDeserialize(using = classOf[JobDeserializer])
@@ -110,7 +113,8 @@ case class ScheduleBasedJob(
                              @JsonProperty override val shell: Boolean = true,
                              @JsonProperty override val arguments: Seq[String] = List(),
                              @JsonProperty override val softError: Boolean = false,
-                             override val dataProcessingJobType: Boolean = false)
+                             @JsonProperty override val dataProcessingJobType: Boolean = false,
+                             @JsonProperty override val constraints: Seq[Constraint] = List())
   extends BaseJob
 
 
@@ -144,5 +148,6 @@ case class DependencyBasedJob(
                                @JsonProperty override val shell: Boolean = true,
                                @JsonProperty override val arguments: Seq[String] = List(),
                                @JsonProperty override val softError: Boolean = false,
-                               override val dataProcessingJobType: Boolean = false)
+                               @JsonProperty override val dataProcessingJobType: Boolean = false,
+                               @JsonProperty override val constraints: Seq[Constraint] = List())
   extends BaseJob

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/Constraint.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/Constraint.scala
@@ -1,0 +1,7 @@
+package org.apache.mesos.chronos.scheduler.jobs.constraints
+
+import org.apache.mesos.Protos
+
+trait Constraint {
+  def matches(attributes: Seq[Protos.Attribute]): Boolean
+}

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/EqualsConstraint.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/EqualsConstraint.scala
@@ -1,0 +1,19 @@
+package org.apache.mesos.chronos.scheduler.jobs.constraints
+
+import org.apache.mesos.Protos
+
+case class EqualsConstraint(attribute: String, value: String) extends Constraint {
+
+  def matches(attributes: Seq[Protos.Attribute]): Boolean = {
+    attributes.foreach { a =>
+      if (a.getName == attribute && a.getText.getValue == value) {
+        return true
+      }
+    }
+    false
+  }
+}
+
+object EqualsConstraint {
+  val OPERATOR = "EQUALS"
+}

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobSerializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobSerializer.scala
@@ -1,6 +1,7 @@
 package org.apache.mesos.chronos.utils
 
 import org.apache.mesos.chronos.scheduler.jobs.{BaseJob, DependencyBasedJob, ScheduleBasedJob}
+import org.apache.mesos.chronos.scheduler.jobs.constraints.EqualsConstraint
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.{JsonSerializer, SerializerProvider}
 
@@ -135,6 +136,20 @@ class JobSerializer extends JsonSerializer[BaseJob] {
       json.writeEndArray()
       json.writeEndObject()
     }
+
+    json.writeFieldName("constraints")
+    json.writeStartArray()
+    baseJob.constraints.foreach { v =>
+      json.writeStartArray()
+      v match {
+        case EqualsConstraint(attribute, value) =>
+          json.writeString(attribute)
+          json.writeString(EqualsConstraint.OPERATOR)
+          json.writeString(value)
+      }
+      json.writeEndArray()
+    }
+    json.writeEndArray()
 
     baseJob match {
       case depJob: DependencyBasedJob =>

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/api/SerDeTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/api/SerDeTest.scala
@@ -1,5 +1,6 @@
 package org.apache.mesos.chronos.scheduler.api
 
+import org.apache.mesos.chronos.scheduler.jobs.constraints.EqualsConstraint
 import org.apache.mesos.chronos.scheduler.jobs.{DependencyBasedJob, DockerContainer, EnvironmentVariable, ScheduleBasedJob, _}
 import org.apache.mesos.chronos.utils.{JobDeserializer, JobSerializer}
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -33,10 +34,12 @@ class SerDeTest extends SpecificationWithJUnit {
         "-testOne"
       )
 
+      val constraints = List(EqualsConstraint("rack", "rack-1"))
+
       val a = new DependencyBasedJob(Set("B", "C", "D", "E"), "A", "noop", Minutes.minutes(5).toPeriod, 10L,
         20L, "fooexec", "fooflags", 7, "foo@bar.com", "Foo", "Test dependency-based job", "TODAY",
         "YESTERDAY", true, container = container, environmentVariables = environmentVariables,
-        shell = false, arguments = arguments, softError = true)
+        shell = false, arguments = arguments, softError = true, constraints = constraints)
 
       val aStr = objectMapper.writeValueAsString(a)
       val aCopy = objectMapper.readValue(aStr, classOf[DependencyBasedJob])
@@ -67,10 +70,12 @@ class SerDeTest extends SpecificationWithJUnit {
         "-testOne"
       )
 
+      val constraints = List(EqualsConstraint("rack", "rack-1"))
+
       val a = new ScheduleBasedJob("FOO/BAR/BAM", "A", "noop", Minutes.minutes(5).toPeriod, 10L, 20L,
         "fooexec", "fooflags", 7, "foo@bar.com", "Foo", "Test schedule-based job", "TODAY",
         "YESTERDAY", true, container = container, environmentVariables = environmentVariables,
-        shell = true, arguments = arguments, softError = true)
+        shell = true, arguments = arguments, softError = true, constraints = constraints)
 
       val aStr = objectMapper.writeValueAsString(a)
       val aCopy = objectMapper.readValue(aStr, classOf[ScheduleBasedJob])

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/EqualsConstraintSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/EqualsConstraintSpec.scala
@@ -1,0 +1,32 @@
+package org.apache.mesos.chronos.scheduler.jobs.constraints
+
+import org.apache.mesos.Protos
+import org.specs2.mutable.SpecificationWithJUnit
+
+class EqualsConstraintSpec extends SpecificationWithJUnit {
+
+  def createAttribute(name: String, value: String): Protos.Attribute = {
+    Protos.Attribute.newBuilder()
+      .setName(name)
+      .setText(Protos.Value.Text.newBuilder().setValue(value))
+      .setType(Protos.Value.Type.TEXT)
+      .build()
+  }
+
+  "matches attributes" in {
+    val attributes = List(createAttribute("dc", "north"), createAttribute("rack", "rack-1"))
+
+    val constraint = EqualsConstraint("rack", "rack-1")
+
+    constraint.matches(attributes) must_== true
+  }
+
+  "does not match attributes" in {
+    val attributes = List(createAttribute("dc", "north"), createAttribute("rack", "rack-1"))
+
+    val constraint = EqualsConstraint("rack", "rack-2")
+
+    constraint.matches(attributes) must_== false
+  }
+
+}


### PR DESCRIPTION
This PR adds support for `constraints` as described in #256.

The format to define constraints of a job is the same as in Marathon.
Note that currently only the `CLUSTER` constraint has been implemented.