### PR TITLE
Add try-catch block for initialization

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/Main.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/Main.scala
@@ -39,10 +39,15 @@ object Main extends App {
     )
   }
 
-  run(
-    classOf[ZookeeperService],
-    classOf[HttpService],
-    classOf[JobScheduler],
-    classOf[MetricReporterService]
-  )
+  try {
+    run(
+      classOf[ZookeeperService],
+      classOf[HttpService],
+      classOf[JobScheduler],
+      classOf[MetricReporterService]
+    )
+  } catch {
+      case _ =>
+        System.exit(1)
+  }
 }


### PR DESCRIPTION
Chronos may be hanging when exception happens during initing. Althought
it's hard to reappear, it should be handled.