### PR TITLE
Better logging for insufficient resources

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
@@ -122,7 +122,11 @@ import scala.concurrent.ExecutionContext.Implicits.global
                     tasks.append((taskId, job, offer))
                     generate()
                   case None =>
-                    log.warning("Insufficient resources remaining for task '%s', will append to queue\n.".format(taskId))
+                    val foundResources = offerResources.toIterator.map(_._2.toString()).mkString(",")
+                    log.warning(
+                      "Insufficient resources remaining for task '%s', will append to queue. (Needed: [%s], Found: [%s])"
+                        .stripMargin.format(taskId, neededResources, foundResources)
+                    )
                     taskManager.enqueue(taskId, job.highPriority)
                 }
             }


### PR DESCRIPTION
Add better logging for when a job cannot be scheduled due to insufficient resources.

Resolution for https://github.com/mesos/chronos/issues/394

@elingg 
@michaeljin