### PR TITLE
FIX: Handle None return in getTask

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
@@ -76,12 +76,6 @@ class TaskManager @Inject()(val listeningExecutor: ListeningScheduledExecutorSer
     } else {
       log.info(s"$name queue contains task: $taskId")
       val jobOption = jobGraph.getJobForName(TaskUtils.getJobNameForTaskId(taskId))
-      val jobArguments = TaskUtils.getJobArgumentsForTaskId(taskId)
-      var job = jobOption.get
-
-      if (jobArguments != null && !jobArguments.isEmpty) {
-        job = JobUtils.getJobWithArguments(job, jobArguments)
-      }
 
       //If the job was deleted after the taskId was added to the queue, the task could be empty.
       if (jobOption.isEmpty) {
@@ -92,6 +86,13 @@ class TaskManager @Inject()(val listeningExecutor: ListeningScheduledExecutorSer
         jobStats.updateJobState(jobOption.get.name, CurrentState.idle)
         None
       } else {
+        val jobArguments = TaskUtils.getJobArgumentsForTaskId(taskId)
+        var job = jobOption.get
+
+        if (jobArguments != null && !jobArguments.isEmpty) {
+          job = JobUtils.getJobWithArguments(job, jobArguments)
+        }
+
         Some(taskId, job)
       }
     }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManagerSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManagerSpec.scala
@@ -20,5 +20,24 @@ class TaskManagerSpec extends SpecificationWithJUnit with Mockito {
       val actualSeconds = scala.math.round(millis / 1000d)
       actualSeconds must_== expectedSeconds
     }
+
+    "Handle None job option in getTask" in {
+      val mockJobGraph = mock[JobGraph]
+      val mockPersistencStore: PersistenceStore = mock[PersistenceStore]
+
+      val taskManager = new TaskManager(mock[ListeningScheduledExecutorService], mockPersistencStore,
+        mockJobGraph, null, mock[JobStats], mock[MetricRegistry])
+
+      val job = new ScheduleBasedJob("R/2012-01-01T00:00:01.000Z/PT1M", "test", "sample-command")
+
+      mockJobGraph.lookupVertex("test").returns(Some(job)) // so we can enqueue a job.
+      taskManager.enqueue("ct:1420843781398:0:test:", highPriority = true)
+
+      mockJobGraph.getJobForName("test").returns(None)
+
+      taskManager.getTask must_== None
+
+      there was one(mockPersistencStore).removeTask("ct:1420843781398:0:test:")
+    }
   }
 }


### PR DESCRIPTION
Fix error on chronos startup. 

This fixes a bug I encountered recently. I had deleted some tasks from the chronos UI and when I bounced chronos, it wouldn't come up. The error in the logs pointed to the culprit here:

```
java.util.NoSuchElementException: None.get
```

It looks like code exists to handle the case when jobOption is empty, but we still unconditionally dereference the jobOption.