### PR TITLE
Cleanup of compiler warnings and complete JobStats refactoring

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/notification/JobNotificationObserver.scala
+++ b/src/main/scala/org/apache/mesos/chronos/notification/JobNotificationObserver.scala
@@ -12,7 +12,7 @@ class JobNotificationObserver @Inject()(val notificationClients: List[ActorRef] 
   private[this] val log = Logger.getLogger(getClass.getName)
   val clusterPrefix = clusterName.map(name => s"[$name]").getOrElse("")
 
-  def asObserver: JobsObserver.Observer = {
+  def asObserver: JobsObserver.Observer = JobsObserver.withName({
     case JobRemoved(job) => sendNotification(job, "%s [Chronos] Your job '%s' was deleted!".format(clusterPrefix, job.name), None)
     case JobDisabled(job, cause) => sendNotification(
       job,
@@ -24,7 +24,7 @@ class JobNotificationObserver @Inject()(val notificationClients: List[ActorRef] 
         .format(DateTime.now(DateTimeZone.UTC), job.retries, taskStatus.getTaskId.getValue)
       sendNotification(job, "%s [Chronos] job '%s' failed!".format(clusterPrefix, job.name),
         Some(TaskUtils.appendSchedulerMessage(msg, taskStatus)))
-  }
+  }, getClass.getSimpleName)
 
   def sendNotification(job: BaseJob, subject: String, message: Option[String] = None) {
     for (client <- notificationClients) {

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
@@ -103,13 +103,15 @@ class JobManagementResource @Inject()(val jobScheduler: JobScheduler,
       jobScheduler.deregisterJob(job, persist = true)
       Response.noContent().build
     } catch {
-      case ex: IllegalArgumentException =>
+      case ex: IllegalArgumentException => {
         log.log(Level.INFO, "Bad Request", ex)
         Response.status(Response.Status.BAD_REQUEST).entity(ex.getMessage)
           .build()
-      case ex: Exception =>
+      }
+      case ex: Exception => {
         log.log(Level.WARNING, "Exception while serving request", ex)
         Response.serverError().build
+      }
     }
   }
 

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobsObserver.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobsObserver.scala
@@ -28,4 +28,10 @@ object JobsObserver {
       Some(Unit)
     })
   }
+
+  def withName(observer: Observer, name: String): Observer = new Observer {
+    override def isDefinedAt(event: JobEvent) = observer.isDefinedAt(event)
+    override def apply(event: JobEvent): Unit = observer.apply(event)
+    override def toString(): String = name
+  }
 }

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobsObserver.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobsObserver.scala
@@ -15,8 +15,8 @@ case class JobFailed(job: Either[String, BaseJob], taskStatus: TaskStatus, attem
 case class JobDisabled(job: BaseJob, cause: String) extends JobEvent
 case class JobRetriesExhausted(job: BaseJob, taskStatus: TaskStatus, attempt: Int) extends JobEvent
 case class JobRemoved(job: BaseJob) extends JobEvent
-// For now, Chronos does not expire tasks once they are queued
-//case class JobExpired(job: BaseJob, taskId: String, attempt: Int) extends JobEvent
+// This event is fired when job is disabled (e.g. due to recurrence going to 0) and its queued tasks are purged
+case class JobExpired(job: BaseJob, taskId: String) extends JobEvent
 
 object JobsObserver {
   type Observer = PartialFunction[JobEvent, Unit]

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/ScheduleStream.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/ScheduleStream.scala
@@ -8,15 +8,13 @@ package org.apache.mesos.chronos.scheduler.jobs
  */
 class ScheduleStream(val schedule: String, val jobName: String, val scheduleTimeZone: String = "") {
 
-  def head(): (String, String, String) = {
-    (schedule, jobName, scheduleTimeZone)
-  }
+  def head: (String, String, String) = (schedule, jobName, scheduleTimeZone)
 
   /**
    * Returns a clipped schedule.
    * @return
    */
-  def tail(): Option[ScheduleStream] = {
+  def tail: Option[ScheduleStream] =
     //TODO(FL) Represent the schedule as a data structure instead of a string.
     Iso8601Expressions.parse(schedule, scheduleTimeZone) match {
       case Some((rec, start, per)) =>
@@ -31,5 +29,4 @@ class ScheduleStream(val schedule: String, val jobName: String, val scheduleTime
       case None =>
         None
     }
-  }
 }

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
@@ -85,7 +85,7 @@ class TaskManager @Inject()(val listeningExecutor: ListeningScheduledExecutorSer
         removeTask(taskId)
         None
       } else if (jobOption.get.disabled) {
-        jobsObserver.apply(JobExpired(job, taskId))
+        jobsObserver.apply(JobExpired(jobOption.get, taskId))
         None
       } else {
         val jobArguments = TaskUtils.getJobArgumentsForTaskId(taskId)

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskStat.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskStat.scala
@@ -39,9 +39,7 @@ class TaskStat (@JsonProperty val taskId: String,
   @JsonProperty var numElementsProcessed: Option[Long] = None //used only for output (HTTP GET)
   @JsonProperty var numAdditionalElementsProcessed: Option[Int] = None //used only for input (HTTP POST)
 
-  def getTaskRuntime(): Option[Duration] = {
-    taskDuration
-  }
+  def getTaskRuntime: Option[Duration] = taskDuration
 
   def setTaskStatus(status: ChronosTaskStatus.Value) = {
     //if already a terminal state, ignore
@@ -82,12 +80,12 @@ class TaskStat (@JsonProperty val taskId: String,
     }
   }
 
-  override def toString(): String = {
+  override def toString: String = {
     "taskId=%s job_name=%s slaveId=%s startTs=%s endTs=%s duration=%s status=%s".format(
       taskId, jobName, taskSlaveId,
-      taskStartTs.toString(),
-      taskEndTs.toString(),
-      taskDuration.toString(),
-      taskStatus.toString())
+      taskStartTs.toString,
+      taskEndTs.toString,
+      taskDuration.toString,
+      taskStatus.toString)
   }
 }

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/graph/Exporter.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/graph/Exporter.scala
@@ -22,7 +22,7 @@ object Exporter {
     val jobMap = new mutable.HashMap[String, BaseJob]
     import scala.collection.JavaConversions._
     dag.vertexSet.flatMap(jobGraph.lookupVertex).foreach(x => jobMap.put(x.name, x))
-    jobMap.foreach({ case (k, v) => w.write("node,%s,%s,%s\n".format(k,getLastState(v).toString,jobStats.getJobState(k).toString()))})
+    jobMap.foreach({ case (k, v) => w.write("node,%s,%s,%s\n".format(k,getLastState(v).toString,jobStats.getJobState(k).toString))})
     for (e: DefaultEdge <- dag.edgeSet) {
       val source = dag.getEdgeSource(e)
       val target = dag.getEdgeTarget(e)

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/stats/JobStats.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/stats/JobStats.scala
@@ -1,5 +1,6 @@
 package org.apache.mesos.chronos.scheduler.jobs.stats
 
+import scala.collection._
 import java.util.concurrent.ConcurrentHashMap
 import java.util.logging.{Level, Logger}
 
@@ -35,7 +36,7 @@ class JobStats @Inject()(clusterBuilder: Option[Cluster.Builder], config: Cassan
   private val TASK_STATE: String = "task_state"
   private val TIMESTAMP: String = "ts"
 
-  protected val jobStates = new scala.collection.mutable.HashMap[String, CurrentState.Value]()
+  protected val jobStates = new mutable.HashMap[String, CurrentState.Value]()
 
   val log = Logger.getLogger(getClass.getName)
   val statements = new ConcurrentHashMap[String, PreparedStatement]().asScala
@@ -210,7 +211,7 @@ class JobStats @Inject()(clusterBuilder: Option[Cluster.Builder], config: Cassan
    * @return list of past and current running tasks for the job
    */
   private def getParsedTaskStatsByJob(job: BaseJob): List[TaskStat] = {
-    val taskMap = scala.collection.mutable.Map[String, TaskStat]()
+    val taskMap = mutable.Map[String, TaskStat]()
 
     getTaskDataByJob(job).fold {
       log.info("No row list found for jobName=%s".format(job.name))

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/stats/JobStats.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/stats/JobStats.scala
@@ -313,14 +313,14 @@ class JobStats @Inject()(clusterBuilder: Option[Cluster.Builder], config: Cassan
     }
   }
 
-  def asObserver: JobsObserver.Observer = {
+  def asObserver: JobsObserver.Observer = JobsObserver.withName({
     case JobExpired(job, _) => updateJobState(job.name, CurrentState.idle)
     case JobRemoved(job) => removeJobState(job)
     case JobQueued(job, taskId, attempt) => jobQueued(job, taskId, attempt)
     case JobStarted(job, taskStatus, attempt) => jobStarted(job, taskStatus, attempt)
     case JobFinished(job, taskStatus, attempt) => jobFinished(job, taskStatus, attempt)
     case JobFailed(job, taskStatus, attempt) => jobFailed(job, taskStatus, attempt)
-  }
+  }, getClass.getSimpleName)
 
   private def jobQueued(job: BaseJob, taskId: String, attempt: Int) {
     updateJobState(job.name, CurrentState.queued)

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/state/MesosStatePersistenceStore.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/state/MesosStatePersistenceStore.scala
@@ -134,7 +134,7 @@ class MesosStatePersistenceStore @Inject()(val zk: CuratorFramework,
     for (f: String <- state.names.get) {
       if (f.startsWith(taskPrefix)) {
         if (filter.isEmpty || f.contains(filter.get)) {
-          results += f.substring(taskPrefix.size)
+          results += f.substring(taskPrefix.length)
         }
       }
     }
@@ -148,7 +148,7 @@ class MesosStatePersistenceStore @Inject()(val zk: CuratorFramework,
       import scala.collection.JavaConversions._
       for (f: String <- state.names.get) {
         if (f.startsWith(taskPrefix)) {
-          val taskId = f.substring(taskPrefix.size)
+          val taskId = f.substring(taskPrefix.length)
           if (TaskUtils.isValidVersion(f)) {
             val data = state.fetch(f).get.value
             results += (taskId -> data)

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobSerializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobSerializer.scala
@@ -121,13 +121,13 @@ class JobSerializer extends JsonSerializer[BaseJob] {
       json.writeStartArray()
       baseJob.container.volumes.foreach { v =>
         json.writeStartObject()
-        v.hostPath.map { hostPath =>
+        v.hostPath.foreach { hostPath =>
           json.writeFieldName("hostPath")
           json.writeString(hostPath)
         }
         json.writeFieldName("containerPath")
         json.writeString(v.containerPath)
-        v.mode.map { mode =>
+        v.mode.foreach { mode =>
           json.writeFieldName("mode")
           json.writeString(mode.toString)
         }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerIntegrationTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerIntegrationTest.scala
@@ -26,7 +26,7 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
       scheduler.registerJob(job1, persist = true, startTime)
 
       val newStreams = scheduler.iteration(startTime, scheduler.streams)
-      newStreams(0).schedule must_== "R4/2012-01-02T00:00:00.000Z/P1D"
+      newStreams.head.schedule must_== "R4/2012-01-02T00:00:00.000Z/P1D"
 
       scheduler.handleFailedTask(TaskUtils.getTaskStatus(job1, startTime, 0))
       scheduler.handleFailedTask(TaskUtils.getTaskStatus(job1, startTime, 0))

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerSpec.scala
@@ -108,7 +108,7 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
       // First one passed, next invocation is 01:01 (b/c of 20 second epsilon)
       // Horizon is 5 minutes, so lookforward until 00:06:01.000Z
       val newScheduleStreams = scheduler.iteration(DateTime.parse("2012-01-01T00:01:01.000Z"), List(jobStream))
-      val (isoExpr, _, _) = newScheduleStreams(0).head()
+      val (isoExpr, _, _) = newScheduleStreams.head.head
 
       var date: DateTime = new DateTime()
       Iso8601Expressions.parse(isoExpr) match {
@@ -134,7 +134,7 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
       val horizon = Minutes.minutes(60).toPeriod
       val scheduler = mockScheduler(horizon, null, mockGraph)
       val newScheduleStreams = scheduler.iteration(DateTime.parse("2012-01-01T00:01:01.000Z"), List(jobStream))
-      val (isoExpr, _, _) = newScheduleStreams(0).head()
+      val (isoExpr, _, _) = newScheduleStreams.head.head
 
       var date: DateTime = new DateTime()
       Iso8601Expressions.parse(isoExpr) match {
@@ -238,7 +238,7 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
 
     val res2: List[ScheduleStream] = scheduler.iteration(DateTime.parse("2012-01-01T00:05:00.000Z"), scheduler.streams)
     res2.size must_== 1
-    res2(0).jobName must_== job1.name
+    res2.head.jobName must_== job1.name
   }
 
   "Job scheduler persists job state after runs" in {
@@ -280,6 +280,6 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     scheduler.registerJob(job1, persist = true, startTime)
 
     val newStreams = scheduler.iteration(startTime, scheduler.streams)
-    newStreams(0).schedule must_== "R2/2012-01-04T00:00:00.000Z/P1D"
+    newStreams.head.schedule must_== "R2/2012-01-04T00:00:00.000Z/P1D"
   }
 }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/ScheduleStreamSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/ScheduleStreamSpec.scala
@@ -12,17 +12,17 @@ class ScheduleStreamSpec extends SpecificationWithJUnit {
       val orgSchedule = "R3/2012-01-01T00:00:00.000Z/P1D"
       val stream = new ScheduleStream(orgSchedule, null)
       stream.head must_==(orgSchedule, null, "")
-      stream.tail().get.head must_==("R2/2012-01-02T00:00:00.000Z/P1D", null, "")
-      stream.tail().get.tail().get.head must_==("R1/2012-01-03T00:00:00.000Z/P1D", null, "")
-      stream.tail().get.tail().get.tail().get.head must_==("R0/2012-01-04T00:00:00.000Z/P1D", null, "")
-      stream.tail().get.tail().get.tail().get.tail must_== None
+      stream.tail.get.head must_==("R2/2012-01-02T00:00:00.000Z/P1D", null, "")
+      stream.tail.get.tail.get.head must_==("R1/2012-01-03T00:00:00.000Z/P1D", null, "")
+      stream.tail.get.tail.get.tail.get.head must_==("R0/2012-01-04T00:00:00.000Z/P1D", null, "")
+      stream.tail.get.tail.get.tail.get.tail must_== None
     }
 
     "return a infinite schedule when no repetition is specified" in {
       val orgSchedule = "R/2012-01-01T00:00:00.000Z/P1D"
       val stream = new ScheduleStream(orgSchedule, null)
       stream.head must_==(orgSchedule, null, "")
-      stream.tail().get.head must_==("R/2012-01-02T00:00:00.000Z/P1D", null, "")
+      stream.tail.get.head must_==("R/2012-01-02T00:00:00.000Z/P1D", null, "")
     }
   }
 

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManagerSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManagerSpec.scala
@@ -1,7 +1,6 @@
 package org.apache.mesos.chronos.scheduler.jobs
 
 import org.apache.mesos.chronos.scheduler.graph.JobGraph
-import org.apache.mesos.chronos.scheduler.jobs.stats.JobStats
 import org.apache.mesos.chronos.scheduler.state.PersistenceStore
 import com.codahale.metrics.MetricRegistry
 import com.google.common.util.concurrent.ListeningScheduledExecutorService

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManagerSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManagerSpec.scala
@@ -26,7 +26,7 @@ class TaskManagerSpec extends SpecificationWithJUnit with Mockito {
       val mockPersistencStore: PersistenceStore = mock[PersistenceStore]
 
       val taskManager = new TaskManager(mock[ListeningScheduledExecutorService], mockPersistencStore,
-        mockJobGraph, null, mock[JobStats], mock[MetricRegistry])
+        mockJobGraph, null, MockJobUtils.mockFullObserver, mock[MetricRegistry])
 
       val job = new ScheduleBasedJob("R/2012-01-01T00:00:01.000Z/PT1M", "test", "sample-command")
 

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManagerSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManagerSpec.scala
@@ -14,7 +14,7 @@ class TaskManagerSpec extends SpecificationWithJUnit with Mockito {
   "TaskManager" should {
     "Calculate the correct time delay between scheduling and dispatching the job" in {
       val taskManager = new TaskManager(mock[ListeningScheduledExecutorService], mock[PersistenceStore],
-        mock[JobGraph], null, mock[JobStats], mock[MetricRegistry])
+        mock[JobGraph], null, MockJobUtils.mockFullObserver, mock[MetricRegistry])
       val millis = taskManager.getMillisUntilExecution(new DateTime(DateTimeZone.UTC).plus(Hours.ONE))
       val expectedSeconds = scala.math.round(Period.hours(1).toStandardDuration.getMillis / 1000d)
       //Due to startup time / JVM overhead, millis wouldn't be totally accurate.


### PR DESCRIPTION
This PR contains #436 in it. It adds proper firing of JobQueued via the new interface and adds JobExpired callback. It also makes corresponding methods in JobStats private, to make sure that they are not called from anywhere but the Observer interface.

Out of boredom, I cleaned up a good number of warnings in several classes to make IntelliJ happy.