### PR TITLE
DOCKER: better entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN echo "deb http://repos.mesosphere.io/ubuntu/ trusty main" > /etc/apt/sources
     default-jdk \
     mesos \
     scala \
-    curl
+    curl && \
+    apt-get clean all
 
 ADD . /chronos
 
@@ -17,6 +18,6 @@ WORKDIR /chronos
 
 RUN mvn clean package
 
-EXPOSE 8081
+EXPOSE 8080
 
 ENTRYPOINT ["bin/start-chronos.bash"]

--- a/bin/start-chronos.bash
+++ b/bin/start-chronos.bash
@@ -1,10 +1,9 @@
 #!/bin/bash
-set -o errexit -o pipefail
+set -o errexit -o nounset -o pipefail
 
 # allow overriding ENTRYPOINT
 # see https://github.com/docker-library/official-images/issues/692
-if [ -z "$1" ] || [ "${1:0:1}" == '-' ]; then
-  set -o errexit -o nounset -o pipefail
+if [ "${1:-absent}" == "absent" ] || [ "${1:0:1}" == '-' ]; then
   flags=( "$@" )
 
   heap=384m

--- a/bin/start-chronos.bash
+++ b/bin/start-chronos.bash
@@ -1,27 +1,39 @@
 #!/bin/bash
-set -o errexit -o nounset -o pipefail
+set -o errexit -o pipefail
 
-chronos_home="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd -P )"
-echo "Chronos home set to $chronos_home"
-export JAVA_LIBRARY_PATH="/usr/local/lib:/lib:/usr/lib"
-export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-/lib}"
-export LD_LIBRARY_PATH="$JAVA_LIBRARY_PATH:$LD_LIBRARY_PATH"
+# allow overriding ENTRYPOINT
+# see https://github.com/docker-library/official-images/issues/692
+if [ -z "$1" ] || [ "${1:0:1}" == '-' ]; then
+  set -o errexit -o nounset -o pipefail
+  flags=( "$@" )
 
-flags=( "$@" )
+  heap=384m
+  chronos_home="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd -P )"
+  echo "Chronos home set to $chronos_home"
+  export JAVA_LIBRARY_PATH="/usr/local/lib:/lib:/usr/lib"
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-/lib}"
+  export LD_LIBRARY_PATH="$JAVA_LIBRARY_PATH:$LD_LIBRARY_PATH"
 
-#If we're on Amazon, let's use the public hostname so redirect works as expected.
-if public_hostname="$( curl -sSf --connect-timeout 1 http://169.254.169.254/latest/meta-data/public-hostname )"
-then
-  flags+=( --hostname $public_hostname )
-else
-  flags+=( --hostname `hostname` )
-fi
 
-jar_files=( "$chronos_home"/target/chronos*.jar )
-echo "Using jar file: $jar_files[0]"
+  #If we're on Amazon, let's use the public hostname so redirect works as expected.
+  if public_hostname="$( curl -sSf --connect-timeout 1 http://169.254.169.254/latest/meta-data/public-hostname 2>/dev/null)"
+  then
+    flags+=( --hostname $public_hostname )
+  else
+    flags+=( --hostname `hostname` )
+  fi
 
-heap=384m
+  jar_files=( "$chronos_home"/target/chronos*.jar )
+  echo "Using jar file: $jar_files[0]"
 
-java -Xmx"$heap" -Xms"$heap" -cp "${jar_files[0]}" \
+  # start zookeeper if we are inside docker container
+  if test -f /.dockerinit; then
+    echo "Starting Zookeeer.."
+    service zookeeper start
+  fi
+  set -- java -Xmx"$heap" -Xms"$heap" -cp "${jar_files[0]}" \
      org.apache.mesos.chronos.scheduler.Main \
      "${flags[@]}"
+fi
+
+exec "$@"


### PR DESCRIPTION
As per Docker-Library best practices, it's best to  allow  overriding ENTRYPOINT, when needed by checking  for  "-"  arguments.
Examples:
`docker run -it chronos` is possible, and so is passing flags:
`docker run -it chronos --help` will work as expected / before.
`docker run -it chronos /bin/bash` and similar is now possible.

See https://github.com/docker-library/official-images/issues/692