### PR TITLE
Forbid using canBeReadonly when connecting zookeeper

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/config/ZookeeperModule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/config/ZookeeperModule.scala
@@ -31,7 +31,7 @@ class ZookeeperModule(val config: SchedulerConfiguration with HttpConf)
   def provideZookeeperClient(): CuratorFramework = {
     val curator = CuratorFrameworkFactory.builder()
       .connectionTimeoutMs(config.zooKeeperTimeout().toInt)
-      .canBeReadOnly(true)
+      .canBeReadOnly(false)
       .connectString(validateZkServers())
       .retryPolicy(new ExponentialBackoffRetry(1000, 10))
       .build()


### PR DESCRIPTION
Chronos may get a wrong leader path, which may cause a fatal error that:
once the non-leader instance gets an out-of-date leader path and the wrong
path happens to be itself, it will redirects a request to itself  and
then blocks other any requests in less than 1 second. In this circumstance,
scheduler is still running but no rest api responds, even it becomes leader.

So, setting connecting parameter 'canBeReadOnly' to false(default) to provide
Chronos from reading wrong leader info is necessary.