### PR TITLE
Add port_on_host for a visitable port on host

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/config/SchedulerConfiguration.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/config/SchedulerConfiguration.scala
@@ -113,7 +113,11 @@ trait SchedulerConfiguration extends ScallopConf {
   lazy val mesosAuthenticationSecretFile = opt[String]("mesos_authentication_secret_file",
     descr = "Mesos Authentication Secret",
     noshort = true)
-
+  // If Chronos run in Docker with --net=bridge, it should register visitable host:port on zookeeper for proxy.
+  lazy val portOnHost = opt[Int]("port_on_host",
+    descr = "Chronos port on host if using Docker BRIDGE network",
+    noshort = true,
+    default = None)
 
   def zooKeeperHostAddresses: Seq[InetSocketAddress] =
     for (s <- zookeeperServers().split(",")) yield {

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/config/ZookeeperModule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/config/ZookeeperModule.scala
@@ -91,7 +91,7 @@ class ZookeeperModule(val config: SchedulerConfiguration with HttpConf)
     val ensurePath: EnsurePath = new EnsurePath(config.zooKeeperCandidatePath)
     ensurePath.ensure(curator.getZookeeperClient)
 
-    val id = "%s:%d".format(config.hostname(), config.httpPort())
+    val id = "%s:%d".format(config.hostname(), if (config.portOnHost.isEmpty) config.httpPort() else config.portOnHost())
     new LeaderLatch(curator, config.zooKeeperCandidatePath, id)
   }
 }


### PR DESCRIPTION
If Chronos run in Docker with --net=bridge, it should register visitable host:port on zookeeper for proxying requests.