### PR TITLE
Add LIKE constraint

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -352,6 +352,18 @@ Schedule a job on nodes that share a common attribute.
 ...
 "constraints": [["rack", "EQUALS", "rack-1"]],
 ...
+```
 
+### LIKE constraint
+
+Schedule jobs on nodes which attributes match a regular expression.
+
+```json
+...
+"constraints": [["rack", "LIKE", "rack-[1-3]"]],
+...
+```
+
+**Note:** This constraint applies to attributes of type `text` and `scalar` and elements in a `set`, but not `range`.
 
 [json]: http://www.json.org/

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/LikeConstraint.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/LikeConstraint.scala
@@ -1,0 +1,37 @@
+package org.apache.mesos.chronos.scheduler.jobs.constraints
+
+import java.util.logging.Logger
+
+import org.apache.mesos.Protos
+import scala.collection.JavaConversions._
+
+case class LikeConstraint(attribute: String, value: String) extends Constraint {
+
+  val regex = value.r
+
+  private[this] val log = Logger.getLogger(getClass.getName)
+
+  def matches(attributes: Seq[Protos.Attribute]): Boolean = {
+    attributes.find(a => a.getName == attribute).exists { a =>
+      a.getType match {
+        case Protos.Value.Type.SCALAR =>
+          regex.pattern.matcher(a.getScalar.getValue.toString).matches()
+        case Protos.Value.Type.SET =>
+          a.getSet.getItemList.exists(regex.pattern.matcher(_).matches())
+        case Protos.Value.Type.TEXT =>
+          regex.pattern.matcher(a.getText.getValue).matches()
+        case Protos.Value.Type.RANGES =>
+          log.warning("Like constraint does not support attributes of type RANGES")
+          false
+        case _ =>
+          val t = a.getType.getNumber
+          log.warning(s"Unknown constraint with number $t in Like constraint")
+          false
+      }
+    }
+  }
+}
+
+object LikeConstraint {
+  val OPERATOR = "LIKE"
+}

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
@@ -1,5 +1,7 @@
 package org.apache.mesos.chronos.utils
 
+import java.util.regex.Pattern
+
 import org.apache.mesos.chronos.scheduler.config.SchedulerConfiguration
 import org.apache.mesos.chronos.scheduler.jobs._
 import org.apache.mesos.chronos.scheduler.jobs.constraints._
@@ -172,6 +174,8 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
         c.get(1).asText match {
           case EqualsConstraint.OPERATOR =>
             constraints.add(EqualsConstraint(c.get(0).asText, c.get(2).asText))
+          case LikeConstraint.OPERATOR =>
+            constraints.add(LikeConstraint(c.get(0).asText, c.get(2).asText))
           case _ =>
         }
       }

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobSerializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobSerializer.scala
@@ -1,7 +1,7 @@
 package org.apache.mesos.chronos.utils
 
 import org.apache.mesos.chronos.scheduler.jobs.{BaseJob, DependencyBasedJob, ScheduleBasedJob}
-import org.apache.mesos.chronos.scheduler.jobs.constraints.EqualsConstraint
+import org.apache.mesos.chronos.scheduler.jobs.constraints.{LikeConstraint, EqualsConstraint}
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.{JsonSerializer, SerializerProvider}
 
@@ -145,6 +145,10 @@ class JobSerializer extends JsonSerializer[BaseJob] {
         case EqualsConstraint(attribute, value) =>
           json.writeString(attribute)
           json.writeString(EqualsConstraint.OPERATOR)
+          json.writeString(value)
+        case LikeConstraint(attribute, value) =>
+          json.writeString(attribute)
+          json.writeString(LikeConstraint.OPERATOR)
           json.writeString(value)
       }
       json.writeEndArray()

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/api/SerDeTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/api/SerDeTest.scala
@@ -1,6 +1,6 @@
 package org.apache.mesos.chronos.scheduler.api
 
-import org.apache.mesos.chronos.scheduler.jobs.constraints.EqualsConstraint
+import org.apache.mesos.chronos.scheduler.jobs.constraints.{LikeConstraint, EqualsConstraint}
 import org.apache.mesos.chronos.scheduler.jobs.{DependencyBasedJob, DockerContainer, EnvironmentVariable, ScheduleBasedJob, _}
 import org.apache.mesos.chronos.utils.{JobDeserializer, JobSerializer}
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -34,7 +34,10 @@ class SerDeTest extends SpecificationWithJUnit {
         "-testOne"
       )
 
-      val constraints = List(EqualsConstraint("rack", "rack-1"))
+      val constraints = Seq(
+        EqualsConstraint("rack", "rack-1"),
+        LikeConstraint("rack", "rack-[1-3]")
+      )
 
       val a = new DependencyBasedJob(Set("B", "C", "D", "E"), "A", "noop", Minutes.minutes(5).toPeriod, 10L,
         20L, "fooexec", "fooflags", 7, "foo@bar.com", "Foo", "Test dependency-based job", "TODAY",
@@ -70,7 +73,10 @@ class SerDeTest extends SpecificationWithJUnit {
         "-testOne"
       )
 
-      val constraints = List(EqualsConstraint("rack", "rack-1"))
+      val constraints = Seq(
+        EqualsConstraint("rack", "rack-1"),
+        LikeConstraint("rack", "rack-[1-3]")
+      )
 
       val a = new ScheduleBasedJob("FOO/BAR/BAM", "A", "noop", Minutes.minutes(5).toPeriod, 10L, 20L,
         "fooexec", "fooflags", 7, "foo@bar.com", "Foo", "Test schedule-based job", "TODAY",

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/ConstraintSpecHelper.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/ConstraintSpecHelper.scala
@@ -1,0 +1,33 @@
+package org.apache.mesos.chronos.scheduler.jobs.constraints
+
+import org.apache.mesos.Protos
+
+trait ConstraintSpecHelper {
+  def createTextAttribute(name: String, value: String): Protos.Attribute = {
+    Protos.Attribute.newBuilder()
+      .setName(name)
+      .setText(Protos.Value.Text.newBuilder().setValue(value))
+      .setType(Protos.Value.Type.TEXT)
+      .build()
+  }
+
+  def createScalarAttribute(name: String, value: Double): Protos.Attribute = {
+    Protos.Attribute.newBuilder()
+      .setName(name)
+      .setScalar(Protos.Value.Scalar.newBuilder().setValue(value))
+      .setType(Protos.Value.Type.SCALAR)
+      .build()
+  }
+
+  def createSetAttribute(name: String, value: Array[String]): Protos.Attribute = {
+    val set = Protos.Attribute.newBuilder()
+      .setName(name)
+      .setType(Protos.Value.Type.SET)
+
+    val builder = Protos.Value.Set.newBuilder()
+    value.foreach(builder.addItem)
+    set.setSet(builder)
+
+    set.build()
+  }
+}

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/EqualsConstraintSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/EqualsConstraintSpec.scala
@@ -1,20 +1,12 @@
 package org.apache.mesos.chronos.scheduler.jobs.constraints
 
-import org.apache.mesos.Protos
 import org.specs2.mutable.SpecificationWithJUnit
 
-class EqualsConstraintSpec extends SpecificationWithJUnit {
-
-  def createAttribute(name: String, value: String): Protos.Attribute = {
-    Protos.Attribute.newBuilder()
-      .setName(name)
-      .setText(Protos.Value.Text.newBuilder().setValue(value))
-      .setType(Protos.Value.Type.TEXT)
-      .build()
-  }
+class EqualsConstraintSpec extends SpecificationWithJUnit
+  with ConstraintSpecHelper {
 
   "matches attributes" in {
-    val attributes = List(createAttribute("dc", "north"), createAttribute("rack", "rack-1"))
+    val attributes = List(createTextAttribute("dc", "north"), createTextAttribute("rack", "rack-1"))
 
     val constraint = EqualsConstraint("rack", "rack-1")
 
@@ -22,7 +14,7 @@ class EqualsConstraintSpec extends SpecificationWithJUnit {
   }
 
   "does not match attributes" in {
-    val attributes = List(createAttribute("dc", "north"), createAttribute("rack", "rack-1"))
+    val attributes = List(createTextAttribute("dc", "north"), createTextAttribute("rack", "rack-1"))
 
     val constraint = EqualsConstraint("rack", "rack-2")
 

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/LikeConstraintSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/LikeConstraintSpec.scala
@@ -1,0 +1,50 @@
+package org.apache.mesos.chronos.scheduler.jobs.constraints
+
+import java.util.regex.PatternSyntaxException
+
+import org.specs2.mutable.SpecificationWithJUnit
+
+class LikeConstraintSpec extends SpecificationWithJUnit
+  with ConstraintSpecHelper {
+  "matches attributes of type text" in {
+    val attributes = List(createTextAttribute("dc", "north"), createTextAttribute("rack", "rack-1"))
+    val constraint = LikeConstraint("rack", "rack-[1-3]")
+
+    constraint.matches(attributes) must_== true
+
+    val attributes2 = List(createTextAttribute("dc", "north"))
+    val constraint2 = LikeConstraint("dc", "north|south")
+
+    constraint2.matches(attributes2) must_== true
+  }
+
+  "matches attributes of type scalar" in {
+    val attributes = List(createScalarAttribute("number", 1))
+    val constraint = LikeConstraint("number", """\d\.\d""")
+
+    constraint.matches(attributes) must_== true
+  }
+
+  "matches attributes of type set" in {
+    val attributes = List(createSetAttribute("dc", Array("north")))
+    val constraint = LikeConstraint("dc", "^n.*")
+
+    constraint.matches(attributes) must_== true
+
+    val attributes2 = List(createSetAttribute("dc", Array("south")))
+
+    constraint.matches(attributes2) must_== false
+  }
+
+  "does not match attributes" in {
+    val attributes = List(createTextAttribute("dc", "north"), createTextAttribute("rack", "rack-1"))
+
+    val constraint = LikeConstraint("rack", "rack-[2-3]")
+
+    constraint.matches(attributes) must_== false
+  }
+
+  "fails in case of an invalid regular expression" in {
+    LikeConstraint("invalid-regex", "[[[") must throwA[PatternSyntaxException]
+  }
+}


### PR DESCRIPTION
The PR adds a new constraint called LIKE which matches the value of an
attribute of a slave against a regular expression.