### PR TITLE
Update Chronos to allow to start a job with custom arguments

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -66,14 +66,21 @@ Deleting tasks for a job is useful if a job gets stuck. Get a job name from the 
 
 ### Manually Starting a Job
 
-You can manually start a job by issuing an HTTP request.
+You can manually start a job by issuing an HTTP request. You can optionally pass job parameters as JSON hash in request body. Job parameters hash supports the following properties:
+* `"arguments"`: list of command line arguments which is appended to `arguments` defined in job config. If job's `shell` is true `arguments` will be ignored
+
+Here is an example job parameters hash:
+```
+{
+  "arguments":["--debug","true"]
+}
+```
 
 * Endpoint: __/scheduler/job__
 * Method: __PUT__
-* Query string parameters: `arguments` - optional string with a list of command line arguments that is appended to job's `command`
-  * If job's `shell` is true `arguments` will be ignored.
+* Request body: `{"arguments":["-verbose"]}` - optional JSON payload with `JobParams`
 * Example: `curl -L -X PUT chronos-node:8080/scheduler/job/request_event_counter_hourly`
-* Example: `curl -L -X PUT chronos-node:8080/scheduler/job/job_name?arguments=-debug`
+* Example: `curl -L -H 'Content-Type: application/json' -X -d '{job parameters hash}' PUT chronos-node:8080/scheduler/job/job_name`
 * Response: HTTP 204
 
 ### Adding a Scheduled Job

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <!-- runtime deps versions -->
     <akka.version>2.3.6</akka.version>
     <cassandra-driver-core.version>2.1.0</cassandra-driver-core.version>
-    <chaos.version>0.6.5</chaos.version>
+    <chaos.version>0.6.3</chaos.version>
     <commons-math3.version>3.2</commons-math3.version>
     <curator-framework.version>2.6.0</curator-framework.version>
     <guava.version>16.0.1</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <!-- runtime deps versions -->
     <akka.version>2.3.6</akka.version>
     <cassandra-driver-core.version>2.1.0</cassandra-driver-core.version>
-    <chaos.version>0.6.3</chaos.version>
+    <chaos.version>0.6.5</chaos.version>
     <commons-math3.version>3.2</commons-math3.version>
     <curator-framework.version>2.6.0</curator-framework.version>
     <guava.version>16.0.1</guava.version>

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Jobs.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Jobs.scala
@@ -1,7 +1,7 @@
 package org.apache.mesos.chronos.scheduler.jobs
 
 import org.apache.mesos.chronos.scheduler.jobs.constraints.Constraint
-import org.apache.mesos.chronos.utils.JobDeserializer
+import org.apache.mesos.chronos.utils.{JobParamsDeserializer, JobDeserializer}
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.joda.time.{Minutes, Period}
@@ -151,3 +151,8 @@ case class DependencyBasedJob(
                                @JsonProperty override val dataProcessingJobType: Boolean = false,
                                @JsonProperty override val constraints: Seq[Constraint] = List())
   extends BaseJob
+
+@JsonDeserialize(using = classOf[JobParamsDeserializer])
+class JobParams (
+  @JsonProperty val arguments: Seq[String] = List()
+)

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtils.scala
@@ -99,8 +99,9 @@ object TaskUtils {
     })
   }
 
-  def getTaskId(job: BaseJob, due: DateTime, attempt: Int = 0): String = {
-    taskIdTemplate.format(due.getMillis, attempt, job.name, job.arguments.mkString(" "))
+  def getTaskId(job: BaseJob, due: DateTime, attempt: Int = 0, arguments: Seq[String] = List()): String = {
+    val jobArguments = job.arguments ++ arguments
+    taskIdTemplate.format(due.getMillis, attempt, job.name, jobArguments.distinct.mkString(" "))
   }
 
   def getDueTimes(tasks: Map[String, Array[Byte]]): Map[String, (BaseJob, Long, Int)] = {

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobParamsDeserializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobParamsDeserializer.scala
@@ -1,0 +1,30 @@
+package org.apache.mesos.chronos.utils
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.{JsonNode, DeserializationContext, JsonDeserializer}
+import org.apache.mesos.chronos.scheduler.jobs.JobParams
+
+import scala.collection.JavaConversions._
+
+/**
+ * Custom JSON deserializer for job params.
+ * Example JobParams:
+ * {
+ *  "arguments": ["A", "B"]
+ * }
+ */
+class JobParamsDeserializer extends JsonDeserializer[JobParams] {
+  def deserialize(jsonParser: JsonParser, ctxt: DeserializationContext): JobParams = {
+    val codec = jsonParser.getCodec
+    val node = codec.readTree[JsonNode](jsonParser)
+    var arguments = scala.collection.mutable.ListBuffer[String]()
+
+    if (node.has("arguments")) {
+      for (argument <- node.path("arguments")) {
+        arguments += argument.asText()
+      }
+    }
+
+    new JobParams(arguments)
+  }
+}


### PR DESCRIPTION
Current commit re-introduces the the ability to pass job arguments to a force run from https://github.com/mesos/chronos/pull/337 which was lost in https://github.com/mesos/chronos/pull/360/files commit.

PR360/355 fixed the issue with `null` arguments (https://github.com/mesos/chronos/issues/355). I verified that existing functionality (https://mesos.github.io/chronos/docs/api.html#manually-starting-a-job) works without introducing `null` arguments when optional `JobParams` payload is omitted from request
