### PR TITLE
Fixes #509 - Flag for reviveOffers and the duration for which to reject offers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <raven.version>4.1.2</raven.version>
 
     <!-- test deps versions -->
+    <akka-testkit.version>2.3.6</akka-testkit.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.9.5</mockito.version>
     <specs2.version>2.3.10</specs2.version>
@@ -208,6 +209,12 @@
     </dependency>
 
     <!-- Test scope -->
+    <dependency>
+      <groupId>com.typesafe.akka</groupId>
+      <artifactId>akka-testkit_2.11</artifactId>
+      <version>${akka-testkit.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/config/SchedulerConfiguration.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/config/SchedulerConfiguration.scala
@@ -113,6 +113,16 @@ trait SchedulerConfiguration extends ScallopConf {
   lazy val mesosAuthenticationSecretFile = opt[String]("mesos_authentication_secret_file",
     descr = "Mesos Authentication Secret",
     noshort = true)
+  lazy val reviveOffersForNewJobs = opt[Boolean]("revive_offers_for_new_jobs",
+    descr = "Whether to call reviveOffers for new or changed jobs. (Default: do not use reviveOffers) ",
+    default = Some(false))
+  lazy val declineOfferDuration = opt[Long]("decline_offer_duration",
+    descr = "(Default: Use mesos default of 5 seconds) " +
+      "The duration (milliseconds) for which to decline offers by default",
+    default = None)
+  lazy val minReviveOffersInterval = opt[Long]("min_revive_offers_interval",
+    descr = "Do not ask for all offers (also already seen ones) more often than this interval (ms). (Default: 5000)",
+    default = Some(5000))
 
 
   def zooKeeperHostAddresses: Seq[InetSocketAddress] =

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosDriverFactory.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosDriverFactory.scala
@@ -1,14 +1,15 @@
 package org.apache.mesos.chronos.scheduler.mesos
 
+import java.io.{ FileInputStream, IOException }
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.{ Files, Paths }
 import java.util.logging.Logger
 
-import org.apache.mesos.chronos.scheduler.config.SchedulerConfiguration
-import org.apache.mesos.Protos.{Credential, FrameworkInfo, Status}
-import org.apache.mesos.{MesosSchedulerDriver, Scheduler}
 import com.google.protobuf.ByteString
-import java.io.{File, FileInputStream, IOException}
-import java.nio.file.{Files, Paths}
-import java.nio.file.attribute.{PosixFilePermission, PosixFilePermissions}
+import org.apache.mesos.Protos.{ Credential, FrameworkInfo, Status }
+import org.apache.mesos.chronos.scheduler.config.SchedulerConfiguration
+import org.apache.mesos.{ MesosSchedulerDriver, Scheduler, SchedulerDriver }
+
 import scala.collection.JavaConverters.asScalaSetConverter
 
 /**
@@ -20,7 +21,7 @@ class MesosDriverFactory(val mesosScheduler: Scheduler, val frameworkInfo: Frame
 
   private[this] val log = Logger.getLogger(getClass.getName)
 
-  var mesosDriver: Option[MesosSchedulerDriver] = None
+  var mesosDriver: Option[SchedulerDriver] = None
 
   def start() {
     val status = get().start()
@@ -30,7 +31,7 @@ class MesosDriverFactory(val mesosScheduler: Scheduler, val frameworkInfo: Frame
     }
   }
 
-  def get(): MesosSchedulerDriver = {
+  def get(): SchedulerDriver = {
     if (mesosDriver.isEmpty) {
       makeDriver()
     }

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosOfferReviver.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosOfferReviver.scala
@@ -1,0 +1,8 @@
+package org.apache.mesos.chronos.scheduler.mesos
+
+/**
+  * Request offers from Mesos that we have already seen because we have new launching requirements.
+  */
+trait MesosOfferReviver {
+  def reviveOffers(): Unit
+}

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosOfferReviverActor.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosOfferReviverActor.scala
@@ -1,0 +1,68 @@
+package org.apache.mesos.chronos.scheduler.mesos
+
+import akka.actor.{ Props, Cancellable, ActorLogging, Actor }
+import akka.event.LoggingReceive
+import com.codahale.metrics.MetricRegistry
+import org.apache.mesos.chronos.scheduler.config.SchedulerConfiguration
+import org.apache.mesos.chronos.utils.Timestamp
+import scala.concurrent.duration._
+
+object MesosOfferReviverActor {
+  final val NAME = "mesosOfferReviver"
+
+  def props(config: SchedulerConfiguration, mesosDriverFactory: MesosDriverFactory, registry: MetricRegistry): Props = {
+    Props(new MesosOfferReviverActor(config, mesosDriverFactory, registry))
+  }
+}
+
+/**
+ * Revive offers whenever interest is signaled but maximally every 5 seconds.
+ */
+class MesosOfferReviverActor(
+  config: SchedulerConfiguration,
+  mesosDriverFactory: MesosDriverFactory,
+  registry: MetricRegistry) extends Actor with ActorLogging {
+    private[this] var lastRevive: Timestamp = Timestamp(0)
+    private[this] var nextReviveCancellableOpt: Option[Cancellable] = None
+
+    private[this] val reviveCounter = registry.counter(
+      MetricRegistry.name(classOf[MesosOfferReviver], "reviveOffersCount"))
+
+    private[this] def reviveOffers(): Unit = {
+      val now: Timestamp = Timestamp.now()
+      val nextRevive: Timestamp = lastRevive + config.minReviveOffersInterval().milliseconds
+
+      if (nextRevive <= now) {
+        log.info("=> reviving offers NOW, canceling any scheduled revives")
+        nextReviveCancellableOpt.foreach(_.cancel())
+        nextReviveCancellableOpt = None
+
+        mesosDriverFactory.mesosDriver.foreach(_.reviveOffers())
+        lastRevive = now
+
+        reviveCounter.inc()
+      }
+      else {
+        lazy val untilNextRevive = now until nextRevive
+        if (nextReviveCancellableOpt.isEmpty) {
+          log.info("=> Scheduling next revive at {} in {}, adhering to --{} {} (ms)",
+            nextRevive, untilNextRevive, config.minReviveOffersInterval.name, config.minReviveOffersInterval())
+          nextReviveCancellableOpt = Some(scheduleCheck(untilNextRevive))
+        }
+        else {
+          log.info("=> Next revive already scheduled at {}, due in {}", nextRevive, untilNextRevive)
+        }
+      }
+    }
+
+    override def receive: Receive = LoggingReceive {
+      case MesosOfferReviverDelegate.ReviveOffers =>
+        log.info("Received request to revive offers")
+        reviveOffers()
+    }
+
+    protected def scheduleCheck(duration: FiniteDuration): Cancellable = {
+      import context.dispatcher
+      context.system.scheduler.scheduleOnce(duration, self, MesosOfferReviverDelegate.ReviveOffers)
+    }
+}

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosOfferReviverDelegate.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosOfferReviverDelegate.scala
@@ -1,0 +1,18 @@
+package org.apache.mesos.chronos.scheduler.mesos
+
+import akka.actor.ActorRef
+import com.codahale.metrics.MetricRegistry
+
+object MesosOfferReviverDelegate {
+  case object ReviveOffers
+}
+
+class MesosOfferReviverDelegate(offerReviverRef: ActorRef, registry: MetricRegistry) extends MesosOfferReviver {
+  val reviveOffersRequestCounter = registry.counter(
+    MetricRegistry.name(classOf[MesosOfferReviver], "reviveOffersRequestCount"))
+
+  override def reviveOffers(): Unit = {
+    reviveOffersRequestCounter.inc()
+    offerReviverRef ! MesosOfferReviverDelegate.ReviveOffers
+  }
+}

--- a/src/main/scala/org/apache/mesos/chronos/utils/Timestamp.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/Timestamp.scala
@@ -1,0 +1,55 @@
+package org.apache.mesos.chronos.utils
+
+import java.util.concurrent.TimeUnit
+
+import org.joda.time.{ DateTime, DateTimeZone }
+
+import scala.concurrent.duration.FiniteDuration
+import scala.math.Ordered
+
+/**
+  * An ordered wrapper for UTC timestamps.
+  */
+abstract case class Timestamp private (utcDateTime: DateTime) extends Ordered[Timestamp] {
+  def compare(that: Timestamp): Int = this.utcDateTime compareTo that.utcDateTime
+
+  override def toString: String = utcDateTime.toString
+
+  def toDateTime: DateTime = utcDateTime
+
+  def until(other: Timestamp): FiniteDuration = {
+    val millis = other.utcDateTime.getMillis - utcDateTime.getMillis
+    FiniteDuration(millis, TimeUnit.MILLISECONDS)
+  }
+
+  def +(duration: FiniteDuration): Timestamp = Timestamp(utcDateTime.getMillis + duration.toMillis)
+  def -(duration: FiniteDuration): Timestamp = Timestamp(utcDateTime.getMillis - duration.toMillis)
+}
+
+object Timestamp {
+  /**
+    * Returns a new Timestamp representing the instant that is the supplied
+    * dateTime converted to UTC.
+    */
+  def apply(dateTime: DateTime): Timestamp = new Timestamp(dateTime.toDateTime(DateTimeZone.UTC)) {}
+
+  /**
+    * Returns a new Timestamp representing the instant that is the supplied
+    * number of milliseconds after the epoch.
+    */
+  def apply(ms: Long): Timestamp = Timestamp(new DateTime(ms))
+
+  /**
+    * Returns a new Timestamp representing the supplied time.
+    *
+    * See the Joda time documentation for a description of acceptable formats:
+    * http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTimeParser()
+    */
+  def apply(time: String): Timestamp = Timestamp(DateTime.parse(time))
+
+  /**
+    * Returns a new Timestamp representing the current instant.
+    */
+  def now(): Timestamp = Timestamp(System.currentTimeMillis)
+
+}

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFrameworkSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFrameworkSpec.scala
@@ -1,0 +1,165 @@
+package org.apache.mesos.chronos.scheduler.mesos
+
+import mesosphere.mesos.protos._
+import mesosphere.mesos.util.FrameworkIdUtil
+import org.apache.mesos.Protos.Offer
+import org.apache.mesos.chronos.scheduler.config.SchedulerConfiguration
+import org.apache.mesos.chronos.scheduler.jobs.{ BaseJob, JobScheduler, TaskManager }
+import org.apache.mesos.{ Protos, SchedulerDriver }
+import org.mockito.Mockito.{ doNothing, doReturn }
+import org.rogach.scallop.ScallopConf
+import org.specs2.mock._
+import org.specs2.mutable._
+
+import scala.collection.mutable
+
+class MesosJobFrameworkSpec extends SpecificationWithJUnit with Mockito {
+
+  private[this] def makeConfig(args: String*): SchedulerConfiguration = {
+    val opts = new ScallopConf(args) with SchedulerConfiguration {
+      // scallop will trigger sys exit
+      override protected def onError(e: Throwable): Unit = throw e
+    }
+    opts.afterInit()
+    opts
+  }
+
+  "MesosJobFramework" should {
+    "Revive offers when registering" in {
+      val mockMesosOfferReviver = mock[MesosOfferReviver]
+
+      val mesosJobFramework = new MesosJobFramework(
+        mock[MesosDriverFactory],
+        mock[JobScheduler],
+        mock[TaskManager],
+        makeConfig(),
+        mock[FrameworkIdUtil],
+        mock[MesosTaskBuilder],
+        mockMesosOfferReviver)
+
+      mesosJobFramework.registered(mock[SchedulerDriver], Protos.FrameworkID.getDefaultInstance,
+        Protos.MasterInfo.getDefaultInstance)
+
+      there was one(mockMesosOfferReviver).reviveOffers()
+    }
+
+    "Revive offers when re-registering" in {
+      val mockMesosOfferReviver = mock[MesosOfferReviver]
+
+      val mesosJobFramework = new MesosJobFramework(
+        mock[MesosDriverFactory],
+        mock[JobScheduler],
+        mock[TaskManager],
+        makeConfig(),
+        mock[FrameworkIdUtil],
+        mock[MesosTaskBuilder],
+        mockMesosOfferReviver)
+
+      mesosJobFramework.reregistered(mock[SchedulerDriver], Protos.MasterInfo.getDefaultInstance)
+
+      there was one(mockMesosOfferReviver).reviveOffers()
+    }
+
+    "Reject unused offers with the default " in {
+      import mesosphere.mesos.protos.Implicits._
+
+      import scala.collection.JavaConverters._
+
+      val mesosDriverFactory = mock[MesosDriverFactory]
+      val schedulerDriver = mock[SchedulerDriver]
+      mesosDriverFactory.get().returns(schedulerDriver)
+
+      val mesosJobFramework = spy(
+        new MesosJobFramework(
+          mesosDriverFactory,
+          mock[JobScheduler],
+          mock[TaskManager],
+          makeConfig(),
+          mock[FrameworkIdUtil],
+          mock[MesosTaskBuilder],
+          mock[MesosOfferReviver]))
+
+      val tasks = mutable.Buffer[(String, BaseJob, Offer)]()
+      doReturn(tasks).when(mesosJobFramework).generateLaunchableTasks(any)
+      doNothing().when(mesosJobFramework).reconcile(any)
+
+      val offer: Offer = makeBasicOffer
+      mesosJobFramework.resourceOffers(mock[SchedulerDriver], Seq[Protos.Offer](offer).asJava)
+
+      there was one (schedulerDriver).declineOffer(OfferID("1"), Protos.Filters.getDefaultInstance)
+    }
+
+    "Reject unused offers with default RefuseSeconds if --decline_offer_duration is not set" in {
+      import mesosphere.mesos.protos.Implicits._
+
+      import scala.collection.JavaConverters._
+
+      val mesosDriverFactory = mock[MesosDriverFactory]
+      val schedulerDriver = mock[SchedulerDriver]
+      mesosDriverFactory.get().returns(schedulerDriver)
+
+      val mesosJobFramework = spy(
+        new MesosJobFramework(
+          mesosDriverFactory,
+          mock[JobScheduler],
+          mock[TaskManager],
+          makeConfig(),
+          mock[FrameworkIdUtil],
+          mock[MesosTaskBuilder],
+          mock[MesosOfferReviver]))
+
+      val tasks = mutable.Buffer[(String, BaseJob, Offer)]()
+      doReturn(tasks).when(mesosJobFramework).generateLaunchableTasks(any)
+      doNothing().when(mesosJobFramework).reconcile(any)
+
+      val offer: Offer = makeBasicOffer
+      mesosJobFramework.resourceOffers(mock[SchedulerDriver], Seq[Protos.Offer](offer).asJava)
+
+      there was one (schedulerDriver).declineOffer(OfferID("1"), Protos.Filters.getDefaultInstance)
+    }
+  }
+
+  "Reject unused offers with the configured value of RefuseSeconds if --decline_offer_duration is set" in {
+    import mesosphere.mesos.protos.Implicits._
+
+    import scala.collection.JavaConverters._
+
+    val mesosDriverFactory = mock[MesosDriverFactory]
+    val schedulerDriver = mock[SchedulerDriver]
+    mesosDriverFactory.get().returns(schedulerDriver)
+
+    val mesosJobFramework = spy(
+      new MesosJobFramework(
+        mesosDriverFactory,
+        mock[JobScheduler],
+        mock[TaskManager],
+        makeConfig("--decline_offer_duration", "3000"),
+        mock[FrameworkIdUtil],
+        mock[MesosTaskBuilder],
+        mock[MesosOfferReviver]))
+
+    val tasks = mutable.Buffer[(String, BaseJob, Offer)]()
+    doReturn(tasks).when(mesosJobFramework).generateLaunchableTasks(any)
+    doNothing().when(mesosJobFramework).reconcile(any)
+
+    val offer: Offer = makeBasicOffer
+    mesosJobFramework.resourceOffers(mock[SchedulerDriver], Seq[Protos.Offer](offer).asJava)
+
+    val filters = Protos.Filters.newBuilder().setRefuseSeconds(3).build()
+    there was one (schedulerDriver).declineOffer(OfferID("1"), filters)
+  }
+
+  private[this] def makeBasicOffer: Offer = {
+    import mesosphere.mesos.protos.Implicits._
+
+    Protos.Offer.newBuilder()
+      .setId(OfferID("1"))
+      .setFrameworkId(FrameworkID("chronos"))
+      .setSlaveId(SlaveID("slave0"))
+      .setHostname("localhost")
+      .addResources(ScalarResource(Resource.CPUS, 1, "*"))
+      .addResources(ScalarResource(Resource.MEM, 100, "*"))
+      .addResources(ScalarResource(Resource.DISK, 100, "*"))
+      .build()
+  }
+}

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/mesos/MesosOfferReviverActorSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/mesos/MesosOfferReviverActorSpec.scala
@@ -1,0 +1,110 @@
+package org.apache.mesos.chronos.scheduler.mesos
+
+import akka.actor._
+import akka.testkit.TestProbe
+import com.codahale.metrics.{ Counter, MetricRegistry }
+import org.apache.mesos.Protos.FrameworkInfo
+import org.apache.mesos.SchedulerDriver
+import org.apache.mesos.chronos.scheduler.config.SchedulerConfiguration
+import org.specs2.mock.Mockito
+import org.specs2.mutable._
+
+import scala.concurrent.duration.FiniteDuration
+
+class MesosOfferReviverActorSpec extends SpecificationWithJUnit with Mockito {
+  "MesosOfferReviverActor" should {
+    "Call the driver's reviveOffers on ReviveOffers message" in new context {
+      val actorRef = startActor()
+
+      delegate.reviveOffers()
+
+      // wait for the actor to process all messages and die
+      actorRef ! PoisonPill
+      val probe = TestProbe()
+      probe.watch(actorRef)
+      probe.expectMsgAnyClassOf(classOf[Terminated])
+
+      there was one(driverFactory.get).reviveOffers()
+    }
+
+    "increment the reviveOffersCounter when it revives offers" in new context {
+      val actorRef = startActor()
+
+      delegate.reviveOffers()
+
+      // wait for the actor to process all messages and die
+      actorRef ! PoisonPill
+      val probe = TestProbe()
+      probe.watch(actorRef)
+      probe.expectMsgAnyClassOf(classOf[Terminated])
+
+      actorSystem.shutdown()
+      actorSystem.awaitTermination()
+
+      there was one(reviveOffersCounter).inc()
+    }
+
+    "Second revive offers message results in scheduling a call to the driver's reviveOffers method" in new context {
+      @volatile
+      var scheduleCheckCalled = 0
+
+      val actorRef = startActor(Props(
+        new MesosOfferReviverActor(conf, driverFactory, metrics) {
+          override protected def scheduleCheck(duration: FiniteDuration): Cancellable = {
+            scheduleCheckCalled += 1
+            mock[Cancellable]
+          }
+        }
+      ))
+
+      delegate.reviveOffers()
+      delegate.reviveOffers()
+
+      // wait for the actor to process all messages and die
+      actorRef ! PoisonPill
+      val probe = TestProbe()
+      probe.watch(actorRef)
+      probe.expectMsgAnyClassOf(classOf[Terminated])
+
+      there was one(driverFactory.mesosDriver.get).reviveOffers()
+      there was one(reviveOffersCounter).inc()
+
+      scheduleCheckCalled must beEqualTo(1)
+    }
+  }
+}
+
+trait context extends BeforeAfter with Mockito {
+  implicit var actorSystem: ActorSystem = _
+  var driverFactory: MesosDriverFactory = _
+  var conf: SchedulerConfiguration = _
+  var delegate: MesosOfferReviverDelegate = _
+  var metrics: MetricRegistry = _
+  var reviveOffersCounter: Counter = _
+
+  def before = {
+    actorSystem = ActorSystem()
+    conf = new SchedulerConfiguration {}
+    conf.afterInit()
+    driverFactory = new MesosDriverFactory(mock[org.apache.mesos.Scheduler], FrameworkInfo.getDefaultInstance, conf)
+    driverFactory.mesosDriver = Some(mock[SchedulerDriver])
+
+    metrics = spy(new MetricRegistry())
+    reviveOffersCounter = metrics.register(
+      MetricRegistry.name(classOf[MesosOfferReviver], "reviveOffersCount"),
+      mock[Counter]
+    )
+  }
+
+  def after = {
+    actorSystem.shutdown()
+    actorSystem.awaitTermination()
+  }
+
+  def startActor(props: Props = MesosOfferReviverActor.props(conf, driverFactory, metrics)): ActorRef = {
+    val actorRef = actorSystem.actorOf(props, MesosOfferReviverActor.NAME)
+    delegate = new MesosOfferReviverDelegate(actorRef, metrics)
+
+    actorRef
+  }
+}

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/mesos/MesosOfferReviverDelegateSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/mesos/MesosOfferReviverDelegateSpec.scala
@@ -1,0 +1,45 @@
+package org.apache.mesos.chronos.scheduler.mesos
+
+import java.util.concurrent.TimeUnit
+
+import akka.actor.ActorSystem
+import akka.testkit.TestProbe
+import com.codahale.metrics.{ Counter, MetricRegistry }
+import org.specs2.mock._
+import org.specs2.mutable._
+
+import scala.concurrent.duration._
+
+class MesosOfferReviverDelegateSpec extends SpecificationWithJUnit with Mockito {
+  implicit lazy val system = ActorSystem()
+
+  "MesosOfferReviverDelegate" should {
+    "Send a ReviveOffers message " in {
+      val registry = spy(new MetricRegistry())
+      val testProbe = TestProbe()
+      val mesosOfferReviverDelegate = new MesosOfferReviverDelegate(testProbe.ref, registry)
+
+      mesosOfferReviverDelegate.reviveOffers()
+
+      testProbe.expectMsg(FiniteDuration(500, TimeUnit.MILLISECONDS), MesosOfferReviverDelegate.ReviveOffers)
+
+      ok
+    }
+
+    "Increment the ReviveOfferRequests counter" in {
+      val registry = spy(new MetricRegistry())
+
+      val reviveOffersRequestCounter = registry.register(
+        MetricRegistry.name(classOf[MesosOfferReviver], "reviveOffersRequestCount"),
+        mock[Counter]
+      )
+
+      val testProbe = TestProbe()
+      val mesosOfferReviverDelegate = new MesosOfferReviverDelegate(testProbe.ref, registry)
+
+      mesosOfferReviverDelegate.reviveOffers()
+
+      there was one(reviveOffersRequestCounter).inc()
+    }
+  }
+}


### PR DESCRIPTION
@ConnorDoyle @elingg @brndnmtthws 

**NOTE**: I plan to add some tests tomorrow, but I would really appreciate if I could get any feedback in the meantime. This has already been done to Marathon, please see https://github.com/mesosphere/marathon/issues/1931.

Add the following command line flags:

`--revive_offers_for_new_jobs` if true, revive offers is called when a new job
is added to the `TaskManager`.

Also note, that Mesos only filters offers that are a strict sub set of a
rejected offer.

`--decline_offer_duration` allows configuring the duration for which unused
offers are declined.

`--min_revive_offers_interval` if `--revive_offers_for_new_jobs` is specified,
do not call reviveOffers more often than this interval. It defaults to 5
seconds.