### PR TITLE
remove task from persistence store on completion

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
@@ -252,6 +252,9 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
       log.warning("Found old or invalid task, ignoring!")
       return
     }
+
+    persistenceStore.removeTask(taskId)
+
     val jobName = TaskUtils.getJobNameForTaskId(taskId)
     val jobOption = jobGraph.lookupVertex(jobName)
 


### PR DESCRIPTION
Old tasks can take up a lot of space in the persistence store, and can cause chronos to take a long time to start up as it cleans them up. It seems nicer to remove these tasks from the persistence store when they complete.