### PR TITLE
Set the hostname in the framework information proto

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/config/SchedulerConfiguration.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/config/SchedulerConfiguration.scala
@@ -37,8 +37,8 @@ trait SchedulerConfiguration extends ScallopConf {
     descr = "The list of ZooKeeper servers for storing state",
     default = Some("localhost:2181"))
   lazy val hostname = opt[String]("hostname",
-    descr = "The advertised hostname stored in ZooKeeper so another standby " +
-      "host can redirect to this elected leader",
+    descr = "The advertised hostname of this Chronos instance for network communication. This is used by other" +
+      "Chronos instances and the Mesos master to communicate with this instance",
     default = Some(java.net.InetAddress.getLocalHost.getHostName))
   lazy val leaderMaxIdleTimeMs = opt[Int]("leader_max_idle_time",
     descr = "The look-ahead time for scheduling tasks in milliseconds",

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/SchedulerDriverBuilder.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/SchedulerDriverBuilder.scala
@@ -47,6 +47,7 @@ class SchedulerDriverBuilder {
         .setRole(config.mesosRole())
         .setFailoverTimeout(config.failoverTimeoutSeconds())
         .setUser(config.user())
+        .setHostname(config.hostname())
 
       // Set the ID, if provided
       frameworkId.foreach(frameworkInfoBuilder.setId)


### PR DESCRIPTION
Due to a bug in Mesos < 0.24.0, Marathon users have observed JVM crashes
when the framework the host's hostname is nor resolvable
(https://issues.apache.org/jira/browse/MESOS-3145).

This change works around the problem by setting the hostname in the
Framework Information proto.