### PR TITLE
Allow periods in job names

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
@@ -19,7 +19,7 @@ import scala.collection.mutable.ListBuffer
  */
 object JobUtils {
 
-  val jobNamePattern = """([\w\s#_-]+)""".r
+  val jobNamePattern = """([\w\s\.#_-]+)""".r
   val stats = new mutable.HashMap[String, DescriptiveStatistics]()
   val maxValues = 100
   //The object mapper, which is, according to the docs, Threadsafe once configured.

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtilsSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtilsSpec.scala
@@ -64,4 +64,10 @@ class JobUtilsSpec extends SpecificationWithJUnit with Mockito {
     scheduledJobWithArguments.command.toString must_== commandWithArguments
     dependencyJobWithArguments.command.toString must_== commandWithArguments
   }
+
+  "Accepts a job name with periods" in {
+    val jobName = "sample.name"
+
+    JobUtils.isValidJobName(jobName)
+  }
 }


### PR DESCRIPTION
![job_name_fail](https://cloud.githubusercontent.com/assets/5157761/9482588/85227520-4b4a-11e5-950e-aa84ec5f868e.png)

Marathon [allows](https://github.com/mesosphere/marathon/blob/master/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md#id-string) periods in job names, but Chronos rejects jobs with periods in their names. Periods are useful as a delimiter, and there's no obvious reason why they aren't allowed in job names. I updated the regex to allow periods and added a test to check that the job name validation accepts a job name containing periods.

Tests [ran](https://travis-ci.org/carroux/chronos/builds/77242330#L3941) and [passed](https://travis-ci.org/carroux/chronos/builds/77242330#L3946).