### PR TITLE
Fix Dockerfile so node works with Ubuntu base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ RUN echo "deb http://repos.mesosphere.io/ubuntu/ trusty main" > /etc/apt/sources
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
     apt-get update && \
     apt-get install -y maven \
-    node \
     npm \
     default-jdk \
     mesos \
     scala \
     curl && \
-    apt-get clean all
+    apt-get clean all && \
+    ln -s /usr/bin/nodejs /usr/bin/node
 
 ADD . /chronos
 


### PR DESCRIPTION
Removed node package as it is a radio package in Debian/Ubuntu. Added symlink /usr/bin/node pointing at /usr/bin/nodejs.