### PR TITLE
First-Class Schedule Data Structure Used Internally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,6 +318,10 @@
         </executions>
         <configuration>
           <scalaVersion>${scala.version}</scalaVersion>
+          <args>
+            <arg>-feature</arg>
+            <arg>-Xfatal-warnings</arg>
+          </args>
           <jvmArgs>
             <jvmArg>-Xmx2G</jvmArg>
           </jvmArgs>

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/DependentJobResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/DependentJobResource.scala
@@ -65,7 +65,7 @@ class DependentJobResource @Inject()(
               newParentNames.foreach(jobGraph.addDependency(_, newJob.name))
             }
             jobScheduler.removeSchedule(j)
-          case j: ScheduleBasedJob =>
+          case j: InternalScheduleBasedJob =>
             parents.foreach(p => jobGraph.addDependency(p.name, newJob.name))
         }
 

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
@@ -65,13 +65,13 @@ class JobManagementResource @Inject()(val jobScheduler: JobScheduler,
                   jobGraph.addDependency(p.name, newChild.name)
                 }
             }
-          case j: ScheduleBasedJob =>
+          case j: InternalScheduleBasedJob =>
             children.foreach {
               child =>
                 jobGraph.lookupVertex(child).get match {
                   case childJob: DependencyBasedJob =>
-                    val newChild = new ScheduleBasedJob(
-                      schedule = j.schedule,
+                    val newChild = new InternalScheduleBasedJob(
+                      scheduleData = j.scheduleData,
                       scheduleTimeZone = j.scheduleTimeZone,
                       name = childJob.name,
                       command = childJob.command,
@@ -225,12 +225,9 @@ class JobManagementResource @Inject()(val jobScheduler: JobScheduler,
              @QueryParam("offset") offset: Integer
               ) = {
     try {
-      val jobs = ListBuffer[BaseJob]()
       import scala.collection.JavaConversions._
-      jobGraph.dag.vertexSet().map({
-        job =>
-          jobs += jobGraph.getJobForName(job).get
-      })
+
+      val jobs = jobGraph.dag.vertexSet() flatMap jobGraph.getJobForName
 
       val _limit: Integer = limit match {
         case x: Integer =>

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
@@ -227,7 +227,7 @@ class JobManagementResource @Inject()(val jobScheduler: JobScheduler,
     try {
       import scala.collection.JavaConversions._
 
-      val jobs = jobGraph.dag.vertexSet() flatMap jobGraph.getJobForName
+      val jobs = jobGraph.dag.vertexSet().flatMap(jobGraph.getJobForName)
 
       val _limit: Integer = limit match {
         case x: Integer =>

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
@@ -516,13 +516,11 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
           log.info("Task ready for scheduling: %s in range [%s => %s]".format(nextDate, scheduleWindowBegin, scheduleWindowEnd))
           //TODO(FL): Rethink passing the dispatch queue all the way down to the ScheduledTask.
           val task = new ScheduledTask(TaskUtils.getTaskId(job, nextDate), nextDate, job, taskManager)
-          println(s"returning task for date in range: $nextDate")
           return (Some(task), stream.tail)
         }
         // Next instance is too far in the future
         // Needs to be scheduled at a later time, after schedule horizon.
         if (!nextDate.isBefore(now)) {
-          println(s"Skipping, date in future: $nextDate")
           return (None, Some(stream))
         }
         // Next instance is too far in the past (beyond epsilon)
@@ -630,7 +628,6 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
   private final def scheduleStream(now: DateTime, s: ScheduleStream): Option[ScheduleStream] = {
     val (taskOption, stream) = next(now, s)
     if (taskOption.isEmpty) {
-      println("Empty task")
       stream
     } else {
       val encapsulatedJob = taskOption.get.job

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
@@ -91,9 +91,9 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
         lock.synchronized {
           if (!scheduleBasedJob.disabled) {
             JobUtils.makeScheduleStream(scheduleBasedJob, DateTime.now(DateTimeZone.UTC)) foreach { newSchedule =>
-                log.info("updating ScheduleBasedJob:" + scheduleBasedJob.toString)
-                val tmpStreams = streams.filter(_.jobName != scheduleBasedJob.name)
-                streams = iteration(DateTime.now(DateTimeZone.UTC), List(newSchedule) ++ tmpStreams)
+              log.info("updating ScheduleBasedJob:" + scheduleBasedJob.toString)
+              val tmpStreams = streams.filter(_.jobName != scheduleBasedJob.name)
+              streams = iteration(DateTime.now(DateTimeZone.UTC), List(newSchedule) ++ tmpStreams)
             }
           } else {
             log.info("updating ScheduleBasedJob:" + scheduleBasedJob.toString)
@@ -288,9 +288,9 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
         case scheduleBasedJob: InternalScheduleBasedJob =>
           val streamForJob = streams.find(_.jobName == job.name)
 
-          streamForJob foreach { stream =>
+          streamForJob.foreach { stream =>
             stream.schedule.recurrences.foreach { recurRemaining =>
-              if(recurRemaining == 0) {
+              if (recurRemaining == 0) {
                 log.info("Disabling job that reached a zero-recurrence count!")
 
                 val disabledJob = scheduleBasedJob.copy(disabled = true)
@@ -478,7 +478,6 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
     val nextDate = schedule.invocationTime
 
     log.info("Calling next for stream: %s, jobname: %s".format(stream.schedule, jobName))
-    assert(schedule != null, "No valid schedule found: " + schedule)
     assert(jobName != null, "BaseJob cannot be null")
 
     var jobOption: Option[StoredJob] = None

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
@@ -135,9 +135,9 @@ object JobUtils {
     //TODO(FL): Create functions that map strings to jobs
 
     val jobs = store.getJobs
-    val dependencyBasedJobs = jobs.collect({case d: DependencyBasedJob => d }).toList
-    val scheduledJobs= jobs.collect({ case s: InternalScheduleBasedJob => s }).toList
 
+    val dependencyBasedJobs = jobs.collect {case d: DependencyBasedJob => d }.toList
+    val scheduledJobs= jobs.collect { case s: InternalScheduleBasedJob => s }.toList
 
     log.info("Registering jobs:" + scheduledJobs.size)
     scheduler.registerJob(scheduledJobs.toList)
@@ -176,13 +176,13 @@ object JobUtils {
 
     @tailrec
     def skip(scheduleStream: Option[ScheduleStream], now: DateTime, skippedAlready: Int): Option[ScheduleStream] = {
-     scheduleStream match {
+      scheduleStream match {
         case None =>
           log.warning("Filtered job %s as it is no longer valid.".format(originalStream.jobName))
           None
         case Some(stream) =>
           if (!stream.schedule.invocationTime.plus(epsilon).isBefore(now)) {
-            if(skippedAlready != 0) {
+            if (skippedAlready != 0) {
               log.warning("Skipped job %s forward %d iterations, modified start from '%s' to '%s"
                 .format(
                   originalStream.jobName,

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
@@ -2,17 +2,17 @@ package org.apache.mesos.chronos.scheduler.jobs
 
 import java.util.logging.Logger
 
-import org.apache.mesos.chronos.scheduler.state.PersistenceStore
-import org.apache.mesos.chronos.utils.{JobDeserializer, JobSerializer}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
-import com.google.common.base.{Charsets, Joiner}
+import com.google.common.base.Charsets
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics
+import org.apache.mesos.chronos.scheduler.state.PersistenceStore
+import org.apache.mesos.chronos.utils.{JobDeserializer, JobSerializer}
+import org.joda.time.{Period, DateTime}
 import org.joda.time.format.DateTimeFormat
-import org.joda.time.{DateTime, Period, Seconds}
 
+import scala.annotation.tailrec
 import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
 
 /**
  * @author Florian Leibert (flo@leibert.de)
@@ -34,19 +34,93 @@ object JobUtils {
   def toBytes[T <: BaseJob](job: T): Array[Byte] =
     objectMapper.writeValueAsString(job).getBytes(Charsets.UTF_8)
 
+
   def fromBytes(data: Array[Byte]): BaseJob = {
     //TODO(FL): Fix this, as it is very inefficient since we're parsing twice.
     //          Link to article, doing this by creating a deserializer handling polymorphism nicer (but more code):
     //          http://programmerbruce.blogspot.com.es/2011/05/deserialize-json-with-jackson-into.html
     val strData = new String(data, Charsets.UTF_8)
-    val map = objectMapper.readValue(strData, classOf[java.util.Map[String, _]])
 
-    if (map.containsKey("parents"))
-      objectMapper.readValue(strData, classOf[DependencyBasedJob])
-    else if (map.containsKey("schedule"))
-      objectMapper.readValue(strData, classOf[ScheduleBasedJob])
-    else
-      objectMapper.readValue(strData, classOf[BaseJob])
+    objectMapper.readValue(strData, classOf[BaseJob])
+  }
+  
+  def convertJobToStored(job: BaseJob): Option[StoredJob] = job match {
+    case j: ScheduleBasedJob =>
+      Schedule.parse(j.schedule, j.scheduleTimeZone) map { parsedSched =>
+        InternalScheduleBasedJob(
+          parsedSched,
+          name = j.name,
+          command = j.command,
+          epsilon = j.epsilon,
+          successCount = j.successCount,
+          errorCount = j.errorCount,
+          executor = j.executor,
+          executorFlags = j.executorFlags,
+          retries = j.retries,
+          owner = j.owner,
+          ownerName = j.ownerName,
+          description = j.description,
+          lastError = j.lastError,
+          lastSuccess = j.lastSuccess,
+          async = j.async,
+          cpus = j.cpus,
+          disk = j.disk,
+          mem = j.mem,
+          disabled = j.disabled,
+          errorsSinceLastSuccess = j.errorsSinceLastSuccess,
+          uris = j.uris,
+          highPriority = j.highPriority,
+          runAsUser = j.runAsUser,
+          container = j.container,
+          environmentVariables = j.environmentVariables,
+          shell = j.shell,
+          arguments = j.arguments,
+          softError = j.softError,
+          dataProcessingJobType = j.dataProcessingJobType,
+          constraints = j.constraints
+        )
+      }
+    case otherwise: StoredJob => Some(otherwise)
+  }
+
+  def convertStoredToJob(job: StoredJob): BaseJob = job match {
+    case is: InternalScheduleBasedJob => convertInternalScheduleToExternalScheduled(is)
+    case other => other
+  }
+
+  def convertInternalScheduleToExternalScheduled(j: InternalScheduleBasedJob): ScheduleBasedJob = {
+    ScheduleBasedJob(
+      schedule = j.scheduleData.toZeroOffsetISO8601Representation,
+      name = j.name,
+      command = j.command,
+      epsilon = j.epsilon,
+      successCount = j.successCount,
+      errorCount = j.errorCount,
+      executor = j.executor,
+      executorFlags = j.executorFlags,
+      retries = j.retries,
+      owner = j.owner,
+      ownerName = j.ownerName,
+      description = j.description,
+      lastError = j.lastError,
+      lastSuccess = j.lastSuccess,
+      async = j.async,
+      cpus = j.cpus,
+      disk = j.disk,
+      mem = j.mem,
+      disabled = j.disabled,
+      errorsSinceLastSuccess = j.errorsSinceLastSuccess,
+      uris = j.uris,
+      highPriority = j.highPriority,
+      runAsUser = j.runAsUser,
+      container = j.container,
+      environmentVariables = j.environmentVariables,
+      shell = j.shell,
+      arguments = j.arguments,
+      softError = j.softError,
+      dataProcessingJobType = j.dataProcessingJobType,
+      constraints = j.constraints
+    )
   }
 
   def isValidJobName(jobName: String): Boolean = {
@@ -59,17 +133,11 @@ object JobUtils {
   //TODO(FL): Think about moving this back into the JobScheduler, though it might be a bit crowded.
   def loadJobs(scheduler: JobScheduler, store: PersistenceStore) {
     //TODO(FL): Create functions that map strings to jobs
-    val scheduledJobs = new ListBuffer[ScheduleBasedJob]
-    val dependencyBasedJobs = new ListBuffer[DependencyBasedJob]
 
     val jobs = store.getJobs
+    val dependencyBasedJobs = jobs.collect({case d: DependencyBasedJob => d }).toList
+    val scheduledJobs= jobs.collect({ case s: InternalScheduleBasedJob => s }).toList
 
-    jobs.foreach {
-      case d: DependencyBasedJob => dependencyBasedJobs += d
-      case s: ScheduleBasedJob => scheduledJobs += s
-      case x: Any =>
-        throw new IllegalStateException("Error, job is neither ScheduleBased nor DependencyBased:" + x.toString)
-    }
 
     log.info("Registering jobs:" + scheduledJobs.size)
     scheduler.registerJob(scheduledJobs.toList)
@@ -83,12 +151,11 @@ object JobUtils {
     dependencyBasedJobs.foreach {
       x =>
         log.info("mapping:" + x)
-        import scala.collection.JavaConversions._
-        log.info("Adding dependencies for %s -> [%s]".format(x.name, Joiner.on(",").join(x.parents)))
+        log.info("Adding dependencies for %s -> [%s]".format(x.name, x.parents.mkString(",")))
 
         scheduler.jobGraph.parentJobsOption(x) match {
           case None =>
-            log.warning(s"Coudn't find all parents of job ${x.name}... dropping it.")
+            log.warning(s"Couldn't find all parents of job ${x.name}... dropping it.")
             scheduler.jobGraph.removeVertex(x)
           case Some(parentJobs) =>
             parentJobs.foreach {
@@ -100,65 +167,40 @@ object JobUtils {
     }
   }
 
-  def makeScheduleStream(job: ScheduleBasedJob, dateTime: DateTime) = {
-    Iso8601Expressions.parse(job.schedule, job.scheduleTimeZone) match {
-      case Some((_, scheduledTime, _)) =>
-        if (scheduledTime.plus(job.epsilon).isBefore(dateTime)) {
-          skipForward(job, dateTime)
-        } else {
-          Some(new ScheduleStream(job.schedule, job.name, job.scheduleTimeZone))
-        }
-      case None =>
-        None
-    }
+  def makeScheduleStream(job: InternalScheduleBasedJob, dateTime: DateTime): Option[ScheduleStream] = {
+    val scheduleStream = new ScheduleStream(job.name, job.scheduleData)
+    skipForward(scheduleStream, dateTime, job.epsilon)
   }
 
-  def skipForward(job: ScheduleBasedJob, dateTime: DateTime): Option[ScheduleStream] = {
-    Iso8601Expressions.parse(job.schedule, job.scheduleTimeZone) match {
-      case Some((rec, start, per)) =>
-        val skip = calculateSkips(dateTime, start, per)
-        if (rec == -1) {
-          val nStart = start.plus(per.multipliedBy(skip))
-          log.warning("Skipped forward %d iterations, modified start from '%s' to '%s"
-            .format(skip, start.toString(DateTimeFormat.fullDate),
-              nStart.toString(DateTimeFormat.fullDate)))
-          Some(new ScheduleStream(Iso8601Expressions.create(rec, nStart, per), job.name, job.scheduleTimeZone))
-        } else if (rec < skip) {
-          log.warning("Filtered job as it is no longer valid.")
+  def skipForward(originalStream: ScheduleStream, now: DateTime, epsilon: Period, skippedAlready: Int = 0): Option[ScheduleStream] = {
+
+    @tailrec
+    def skip(scheduleStream: Option[ScheduleStream], now: DateTime, skippedAlready: Int): Option[ScheduleStream] = {
+     scheduleStream match {
+        case None =>
+          log.warning("Filtered job %s as it is no longer valid.".format(originalStream.jobName))
           None
-        } else {
-          val nRec = rec - skip
-          val nStart = start.plus(per.multipliedBy(skip))
-          log.warning("Skipped forward %d iterations, iterations is now '%d' , modified start from '%s' to '%s"
-            .format(skip, nRec, start.toString(DateTimeFormat.fullDate),
-              nStart.toString(DateTimeFormat.fullDate)))
-          Some(new ScheduleStream(Iso8601Expressions.create(nRec, nStart, per), job.name, job.scheduleTimeZone))
-        }
-      case None =>
-        None
-    }
-  }
-
-  /**
-   * Calculates the number of skips needed to bring the job start into the future
-   */
-  protected def calculateSkips(dateTime: DateTime, jobStart: DateTime, period: Period): Int = {
-    // If the period is at least a month, we have to actually add the period to the date
-    // until it's in the future because a month-long period might have different seconds
-    if (period.getMonths >= 1) {
-      var skips = 0
-      var newDate = new DateTime(jobStart)
-      while (newDate.isBefore(dateTime)) {
-        newDate = newDate.plus(period)
-        skips += 1
+        case Some(stream) =>
+          if (!stream.schedule.invocationTime.plus(epsilon).isBefore(now)) {
+            if(skippedAlready != 0) {
+              log.warning("Skipped job %s forward %d iterations, modified start from '%s' to '%s"
+                .format(
+                  originalStream.jobName,
+                  skippedAlready,
+                  originalStream.schedule.invocationTime.toString(DateTimeFormat.fullDate),
+                  stream.schedule.invocationTime.toString(DateTimeFormat.fullDate)))
+            }
+            Some(stream)
+          } else {
+            skip(stream.tail, now, skippedAlready + 1)
+          }
       }
-      skips
-    } else {
-      Seconds.secondsBetween(jobStart, dateTime).getSeconds / period.toStandardSeconds.getSeconds
     }
+    println("Checking stream ....")
+    skip(Some(originalStream), now, 0)
   }
 
-  def getJobWithArguments(job: BaseJob, arguments: String): BaseJob = {
+  def getJobWithArguments(job: StoredJob, arguments: String): BaseJob = {
     val commandWithArgs = job.command + " " + arguments
     val jobWithArguments = job match {
       case j: DependencyBasedJob =>
@@ -190,9 +232,9 @@ object JobUtils {
           shell = job.shell,
           arguments = job.arguments
         )
-      case j: ScheduleBasedJob =>
-        new ScheduleBasedJob(
-          schedule = j.schedule,
+      case j: InternalScheduleBasedJob =>
+        new InternalScheduleBasedJob(
+          scheduleData = j.scheduleData,
           scheduleTimeZone = j.scheduleTimeZone,
           name = job.name,
           command = commandWithArgs,

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
@@ -136,8 +136,8 @@ object JobUtils {
 
     val jobs = store.getJobs
 
-    val dependencyBasedJobs = jobs.collect {case d: DependencyBasedJob => d }.toList
-    val scheduledJobs= jobs.collect { case s: InternalScheduleBasedJob => s }.toList
+    val dependencyBasedJobs = jobs.collect { case d: DependencyBasedJob => d }.toList
+    val scheduledJobs = jobs.collect { case s: InternalScheduleBasedJob => s }.toList
 
     log.info("Registering jobs:" + scheduledJobs.size)
     scheduler.registerJob(scheduledJobs.toList)

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
@@ -196,7 +196,6 @@ object JobUtils {
           }
       }
     }
-    println("Checking stream ....")
     skip(Some(originalStream), now, 0)
   }
 

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobsObserver.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobsObserver.scala
@@ -6,17 +6,17 @@ import org.apache.mesos.Protos.TaskStatus
 import org.joda.time.DateTime
 
 trait JobEvent
-case class JobQueued(job: BaseJob, taskId: String, attempt: Int) extends JobEvent
-case class JobSkipped(job: BaseJob, dateTime: DateTime) extends JobEvent
-case class JobStarted(job: BaseJob, taskStatus: TaskStatus, attempt: Int) extends JobEvent
-case class JobFinished(job: BaseJob, taskStatus: TaskStatus, attempt: Int) extends JobEvent
+case class JobQueued(job: StoredJob, taskId: String, attempt: Int) extends JobEvent
+case class JobSkipped(job: StoredJob, dateTime: DateTime) extends JobEvent
+case class JobStarted(job: StoredJob, taskStatus: TaskStatus, attempt: Int) extends JobEvent
+case class JobFinished(job: StoredJob, taskStatus: TaskStatus, attempt: Int) extends JobEvent
 // Either a job name or job object, depending on whether the Job still exists
-case class JobFailed(job: Either[String, BaseJob], taskStatus: TaskStatus, attempt: Int) extends JobEvent
-case class JobDisabled(job: BaseJob, cause: String) extends JobEvent
-case class JobRetriesExhausted(job: BaseJob, taskStatus: TaskStatus, attempt: Int) extends JobEvent
-case class JobRemoved(job: BaseJob) extends JobEvent
+case class JobFailed(job: Either[String, StoredJob], taskStatus: TaskStatus, attempt: Int) extends JobEvent
+case class JobDisabled(job: StoredJob, cause: String) extends JobEvent
+case class JobRetriesExhausted(job: StoredJob, taskStatus: TaskStatus, attempt: Int) extends JobEvent
+case class JobRemoved(job: StoredJob) extends JobEvent
 // This event is fired when job is disabled (e.g. due to recurrence going to 0) and its queued tasks are purged
-case class JobExpired(job: BaseJob, taskId: String) extends JobEvent
+case class JobExpired(job: StoredJob, taskId: String) extends JobEvent
 
 object JobsObserver {
   type Observer = PartialFunction[JobEvent, Unit]

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Schedule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Schedule.scala
@@ -14,7 +14,7 @@ case class Schedule(@JsonProperty schedule: String,
 
 
   def next: Option[Schedule] = {
-    if(recurrences.exists(_ == 0)) None
+    if (recurrences.exists(_ == 0)) None
     else {
       val nextOffset = offset + 1
       val nextInvocationTime = Schedule.addPeriods(originTime, period, nextOffset.asInstanceOf[Int] /* jodatime doesn't support longs in their plus methods. What to do about overflow? */)
@@ -30,9 +30,9 @@ case class Schedule(@JsonProperty schedule: String,
 
 object Schedule {
   def parse(scheduleStr: String, timeZoneStr: String = ""): Option[Schedule] = {
-    Iso8601Expressions.parse(scheduleStr, timeZoneStr) map {
+    Iso8601Expressions.parse(scheduleStr, timeZoneStr).map {
       case (recurrences, start, period) =>
-        Schedule(scheduleStr, timeZoneStr, start, start, offset = 0, if(recurrences == -1) None else Some(recurrences), period)
+        Schedule(scheduleStr, timeZoneStr, start, start, offset = 0, if (recurrences == -1) None else Some(recurrences), period)
     }
   }
 

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Schedule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Schedule.scala
@@ -1,0 +1,44 @@
+package org.apache.mesos.chronos.scheduler.jobs
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.joda.time.{DateTime, Period}
+
+
+case class Schedule(@JsonProperty schedule: String,
+                    @JsonProperty scheduleTimeZone: String,
+                    @JsonProperty invocationTime: DateTime,
+                    @JsonProperty originTime: DateTime,
+                    @JsonProperty offset: Long = 0,
+                    @JsonProperty recurrences: Option[Long] = None,
+                    @JsonProperty period: Period) {
+
+
+  def next: Option[Schedule] = {
+    if(recurrences.exists(_ == 0)) None
+    else {
+      val nextOffset = offset + 1
+      val nextInvocationTime = Schedule.addPeriods(originTime, period, nextOffset.asInstanceOf[Int] /* jodatime doesn't support longs in their plus methods. What to do about overflow? */)
+
+      Some(Schedule(schedule, scheduleTimeZone, nextInvocationTime, originTime, nextOffset, recurrences.map(_ - 1), period))
+    }
+  }
+
+  def toZeroOffsetISO8601Representation: String = {
+    Iso8601Expressions.create(recurrences.getOrElse(-1), invocationTime, period)
+  }
+}
+
+object Schedule {
+  def parse(scheduleStr: String, timeZoneStr: String = ""): Option[Schedule] = {
+    Iso8601Expressions.parse(scheduleStr, timeZoneStr) map {
+      case (recurrences, start, period) =>
+        Schedule(scheduleStr, timeZoneStr, start, start, offset = 0, if(recurrences == -1) None else Some(recurrences), period)
+    }
+  }
+
+
+  // replace with multiplied by?
+  def addPeriods(origin: DateTime, period: Period, number: Int): DateTime = {
+    origin.plus(period.multipliedBy(number))
+  }
+}

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/ScheduleStream.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/ScheduleStream.scala
@@ -6,27 +6,16 @@ package org.apache.mesos.chronos.scheduler.jobs
  * The schedule consists of a string representation of an ISO8601 expression as well as a BaseJob.
  * @author Florian Leibert (flo@leibert.de)
  */
-class ScheduleStream(val schedule: String, val jobName: String, val scheduleTimeZone: String = "") {
+class ScheduleStream(val jobName: String, val schedule: Schedule) {
 
-  def head: (String, String, String) = (schedule, jobName, scheduleTimeZone)
+  def head: (String, Schedule) = (jobName, schedule)
 
   /**
    * Returns a clipped schedule.
    * @return
    */
   def tail: Option[ScheduleStream] =
-    //TODO(FL) Represent the schedule as a data structure instead of a string.
-    Iso8601Expressions.parse(schedule, scheduleTimeZone) match {
-      case Some((rec, start, per)) =>
-        if (rec == -1)
-          Some(new ScheduleStream(Iso8601Expressions.create(rec, start.plus(per), per), jobName,
-            scheduleTimeZone))
-        else if (rec > 0)
-          Some(new ScheduleStream(Iso8601Expressions.create(rec - 1, start.plus(per), per), jobName,
-            scheduleTimeZone))
-        else
-          None
-      case None =>
-        None
-    }
+    schedule.next.map(s => new ScheduleStream(jobName, s))
+
+  override def toString = s"ScheduleStream{ job: $jobName [$schedule] }"
 }

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/ScheduledTask.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/ScheduledTask.scala
@@ -11,7 +11,7 @@ import org.joda.time.DateTime
 class ScheduledTask(
                      val taskId: String,
                      val due: DateTime,
-                     val job: BaseJob,
+                     val job: StoredJob,
                      val taskManager: TaskManager)
   extends Callable[Void] {
 

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtils.scala
@@ -103,12 +103,14 @@ object TaskUtils {
     taskIdTemplate.format(due.getMillis, attempt, job.name, job.arguments.mkString(" "))
   }
 
-  def getDueTimes(tasks: Map[String, Array[Byte]]): Map[String, (BaseJob, Long, Int)] = {
-    val taskMap = new mutable.HashMap[String, (BaseJob, Long, Int)]()
+  def getDueTimes(tasks: Map[String, Array[Byte]]): Map[String, (StoredJob, Long, Int)] = {
+    val taskMap = new mutable.HashMap[String, (StoredJob, Long, Int)]()
 
     tasks.foreach { p: (String, Array[Byte]) => println(p._1)
       //Any non-recurring job R1/X/Y is equivalent to a task!
-      val taskInstance = JobUtils.fromBytes(p._2)
+      val taskInstance = JobUtils.convertJobToStored(JobUtils.fromBytes(p._2)) getOrElse {
+        throw new RuntimeException(s"Failed to migrate task ${p._1}")
+      }
       val taskTuple = parseTaskId(p._1)
       val now = DateTime.now(DateTimeZone.UTC).getMillis
       val lastExecutableTime = new DateTime(taskTuple._2, DateTimeZone.UTC).plus(taskInstance.epsilon).getMillis

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtils.scala
@@ -106,7 +106,7 @@ object TaskUtils {
   def getDueTimes(tasks: Map[String, Array[Byte]]): Map[String, (StoredJob, Long, Int)] = {
     val taskMap = new mutable.HashMap[String, (StoredJob, Long, Int)]()
 
-    tasks.foreach { p: (String, Array[Byte]) => println(p._1)
+    tasks.foreach { p: (String, Array[Byte]) =>
       //Any non-recurring job R1/X/Y is equivalent to a task!
       val taskInstance = JobUtils.convertJobToStored(JobUtils.fromBytes(p._2)) getOrElse {
         throw new RuntimeException(s"Failed to migrate task ${p._1}")

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtils.scala
@@ -108,7 +108,7 @@ object TaskUtils {
 
     tasks.foreach { p: (String, Array[Byte]) =>
       //Any non-recurring job R1/X/Y is equivalent to a task!
-      val taskInstance = JobUtils.convertJobToStored(JobUtils.fromBytes(p._2)) getOrElse {
+      val taskInstance = JobUtils.convertJobToStored(JobUtils.fromBytes(p._2)).getOrElse {
         throw new RuntimeException(s"Failed to migrate task ${p._1}")
       }
       val taskTuple = parseTaskId(p._1)

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
@@ -2,20 +2,19 @@ package org.apache.mesos.chronos.scheduler.mesos
 
 import java.util.logging.Logger
 
+import com.google.inject.Inject
+import mesosphere.mesos.util.FrameworkIdUtil
+import org.apache.mesos.Protos._
 import org.apache.mesos.chronos.scheduler.config.SchedulerConfiguration
 import org.apache.mesos.chronos.scheduler.jobs._
 import org.apache.mesos.chronos.scheduler.jobs.constraints.Constraint
 import org.apache.mesos.chronos.utils.JobDeserializer
-import com.google.inject.Inject
-import mesosphere.mesos.util.FrameworkIdUtil
-import org.apache.mesos.Protos._
 import org.apache.mesos.{Protos, Scheduler, SchedulerDriver}
 import org.joda.time.DateTime
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.collection.mutable.{Buffer, HashMap, HashSet}
 
 /**
  * Provides the interface to chronos. Receives callbacks from chronos when resources are offered, declined etc.

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/state/MesosStatePersistenceStore.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/state/MesosStatePersistenceStore.scala
@@ -59,7 +59,7 @@ class MesosStatePersistenceStore @Inject()(val zk: CuratorFramework,
     }
   }
 
-  def persistJob(job: BaseJob): Boolean = {
+  def persistJob(job: StoredJob): Boolean = {
     log.info("Persisting job '%s' with data '%s'" format(job.name, job.toString))
     persistData(jobName(job.name), JobUtils.toBytes(job))
   }
@@ -98,23 +98,28 @@ class MesosStatePersistenceStore @Inject()(val zk: CuratorFramework,
     remove(taskName(taskId))
   }
 
-  def removeJob(job: BaseJob) {
+  def removeJob(job: StoredJob) {
     log.fine("Removing job:" + job.name)
     remove(jobName(job.name))
   }
 
-  def getJob(name: String): BaseJob = {
+  def getJob(name: String): StoredJob = {
     val bytes = state.fetch(jobName(name)).get
-    JobUtils.fromBytes(bytes.value)
+    JobUtils.convertJobToStored(JobUtils.fromBytes(bytes.value)) getOrElse {
+      throw new RuntimeException(s"Failed to migrate job; error parsing stored data for job $name")
+    }
   }
 
-  def getJobs: Iterator[BaseJob] = {
+  def getJobs: Iterator[StoredJob] = {
 
     import scala.collection.JavaConversions._
 
     state.names.get.filter(_.startsWith(jobPrefix))
       .map({
-      x: String => JobUtils.fromBytes(state.fetch(x).get.value)
+      x: String =>
+        JobUtils.convertJobToStored(JobUtils.fromBytes(state.fetch(x).get.value)) getOrElse {
+          throw new RuntimeException(s"Failed to migrate job; error parsing stored data for job $x")
+        }
     })
   }
 

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/state/MesosStatePersistenceStore.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/state/MesosStatePersistenceStore.scala
@@ -105,7 +105,7 @@ class MesosStatePersistenceStore @Inject()(val zk: CuratorFramework,
 
   def getJob(name: String): StoredJob = {
     val bytes = state.fetch(jobName(name)).get
-    JobUtils.convertJobToStored(JobUtils.fromBytes(bytes.value)) getOrElse {
+    JobUtils.convertJobToStored(JobUtils.fromBytes(bytes.value)).getOrElse {
       throw new RuntimeException(s"Failed to migrate job; error parsing stored data for job $name")
     }
   }
@@ -117,7 +117,7 @@ class MesosStatePersistenceStore @Inject()(val zk: CuratorFramework,
     state.names.get.filter(_.startsWith(jobPrefix))
       .map({
       x: String =>
-        JobUtils.convertJobToStored(JobUtils.fromBytes(state.fetch(x).get.value)) getOrElse {
+        JobUtils.convertJobToStored(JobUtils.fromBytes(state.fetch(x).get.value)).getOrElse {
           throw new RuntimeException(s"Failed to migrate job; error parsing stored data for job $x")
         }
     })

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/state/PersistenceStore.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/state/PersistenceStore.scala
@@ -12,7 +12,7 @@ trait PersistenceStore {
    * @param job
    * @return
    */
-  def persistJob(job: BaseJob): Boolean
+  def persistJob(job: StoredJob): Boolean
 
   /**
    * Saves a taskId in the state abstraction.
@@ -34,14 +34,14 @@ trait PersistenceStore {
    * @param job the job to remove.
    * @return true if the job was saved, false if the job couldn't be saved.
    */
-  def removeJob(job: BaseJob)
+  def removeJob(job: StoredJob)
 
   /**
    * Loads a job from the underlying store
    * @param name
    * @return
    */
-  def getJob(name: String): BaseJob
+  def getJob(name: String): StoredJob
 
   /**
    * Purges all tasks from the underlying store
@@ -65,5 +65,5 @@ trait PersistenceStore {
    * Returns all jobs from the underlying store
    * @return
    */
-  def getJobs: Iterator[BaseJob]
+  def getJobs: Iterator[StoredJob]
 }

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
@@ -272,7 +272,7 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
       val originTime = DateTime.parse(scheduleDataNode.get("originTime").asText())
       val invocationTime = DateTime.parse(scheduleDataNode.get("invocationTime").asText())
       val offset = scheduleDataNode.get("offset").asLong()
-      val recurrences = if(scheduleDataNode.has("recurrences")) Some(scheduleDataNode.get("recurrences").asLong()) else None
+      val recurrences = if (scheduleDataNode.has("recurrences")) Some(scheduleDataNode.get("recurrences").asLong()) else None
       val period = Period.parse(scheduleDataNode.get("period").asText())
 
       new InternalScheduleBasedJob(

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobSerializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobSerializer.scala
@@ -1,9 +1,10 @@
 package org.apache.mesos.chronos.utils
 
-import org.apache.mesos.chronos.scheduler.jobs.{BaseJob, DependencyBasedJob, ScheduleBasedJob}
-import org.apache.mesos.chronos.scheduler.jobs.constraints.{LikeConstraint, EqualsConstraint}
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.{JsonSerializer, SerializerProvider}
+import org.apache.mesos.chronos.scheduler.jobs.constraints.{EqualsConstraint, LikeConstraint}
+import org.apache.mesos.chronos.scheduler.jobs.{BaseJob, DependencyBasedJob, InternalScheduleBasedJob, ScheduleBasedJob}
+import org.joda.time.format.{ISOPeriodFormat, ISODateTimeFormat}
 
 /**
  * Custom JSON serializer for jobs.
@@ -181,8 +182,32 @@ class JobSerializer extends JsonSerializer[BaseJob] {
         json.writeString(schedJob.schedule)
         json.writeFieldName("scheduleTimeZone")
         json.writeString(schedJob.scheduleTimeZone)
-      case _ =>
-        throw new IllegalStateException("The job found was neither schedule based nor dependency based.")
+      case iSchedJob: InternalScheduleBasedJob =>
+        json.writeFieldName("scheduleTimeZone")
+        json.writeString(iSchedJob.scheduleTimeZone)
+        json.writeFieldName("scheduleData")
+        json.writeStartObject()
+
+        json.writeFieldName("schedule")
+        json.writeString(iSchedJob.scheduleData.schedule)
+        json.writeFieldName("scheduleTimeZone")
+        json.writeString(iSchedJob.scheduleData.scheduleTimeZone)
+        json.writeFieldName("originTime")
+        json.writeString(iSchedJob.scheduleData.originTime.toString(ISODateTimeFormat.dateTime))
+        json.writeFieldName("invocationTime")
+        json.writeString(iSchedJob.scheduleData.invocationTime.toString(ISODateTimeFormat.dateTime))
+        json.writeFieldName("offset")
+        json.writeNumber(iSchedJob.scheduleData.offset)
+
+        iSchedJob.scheduleData.recurrences.foreach{ r =>
+          json.writeFieldName("recurrences")
+          json.writeNumber(r)
+        }
+
+        json.writeFieldName("period")
+        json.writeString(iSchedJob.scheduleData.period.toString(ISOPeriodFormat.standard()))
+
+        json.writeEndObject()
     }
 
     json.writeEndObject()

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobSerializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobSerializer.scala
@@ -199,7 +199,7 @@ class JobSerializer extends JsonSerializer[BaseJob] {
         json.writeFieldName("offset")
         json.writeNumber(iSchedJob.scheduleData.offset)
 
-        iSchedJob.scheduleData.recurrences.foreach{ r =>
+        iSchedJob.scheduleData.recurrences.foreach { r =>
           json.writeFieldName("recurrences")
           json.writeNumber(r)
         }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/Iso8601ExpressionParserSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/Iso8601ExpressionParserSpec.scala
@@ -1,6 +1,6 @@
 package org.apache.mesos.chronos.scheduler.jobs
 
-import org.joda.time.{DateTime, Days, Period}
+import org.joda.time.{Minutes, DateTime, Days, Period}
 import org.specs2.mutable._
 
 class Iso8601ExpressionParserSpec extends SpecificationWithJUnit {
@@ -105,12 +105,12 @@ class Iso8601ExpressionParserSpec extends SpecificationWithJUnit {
     }
 
     "Test time zone change when time is not specified" in {
-      val fail = Iso8601Expressions.parse("R/2008-03-01/P1D", "PST") match {
+      val fail = Iso8601Expressions.parse("R/2008-03-01/PT1M", "PST") match {
         case Some((repetitions, startTime, period)) =>
           repetitions must_== -1L
           startTime.getMillis must_== DateTime.parse("2008-03-01T00:00:00-08:00").getMillis
           //This is a hack because Period's equals seems broken!
-          period.toString must_== new Period(Days.ONE).toString
+          period.toString must_== new Period(Minutes.ONE).toString
           false
         case _ =>
           true

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerElectionSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerElectionSpec.scala
@@ -117,7 +117,7 @@ class JobSchedulerElectionSpec
     val mesosDriver: MesosDriverFactory = mock[MesosDriverFactory]
 
     persistenceStore.getTasks returns Map[String, Array[Byte]]()
-    persistenceStore.getJobs returns Iterator[BaseJob]()
+    persistenceStore.getJobs returns Iterator[StoredJob]()
 
     doNothing().when(mesosDriver).start()
 

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerIntegrationTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerIntegrationTest.scala
@@ -1,10 +1,10 @@
 package org.apache.mesos.chronos.scheduler.jobs
 
-import org.apache.mesos.chronos.scheduler.api.{DependentJobResource, Iso8601JobResource}
 import org.apache.mesos.chronos.scheduler.graph.JobGraph
 import org.apache.mesos.chronos.scheduler.state.PersistenceStore
+import org.apache.mesos.chronos.scheduler.api.{DependentJobResource, Iso8601JobResource}
+import org.joda.time._
 import org.joda.time.format.ISODateTimeFormat
-import org.joda.time.{DateTime, DateTimeZone, Hours, Minutes}
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
 
@@ -14,33 +14,48 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
   "JobScheduler" should {
     "A job creates a failed task and then a successful task from a synchronous job" in {
       val epsilon = Hours.hours(2).toPeriod
-      val job1 = new ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD", epsilon)
+      val schedule = Schedule.parse("R5/2012-01-01T00:00:00.000Z/P1D").get
+      val job1 = new InternalScheduleBasedJob(schedule, "job1", "CMD", epsilon)
 
       val jobGraph = new JobGraph
       val persistenceStore = mock[PersistenceStore]
       val mockTaskManager = mock[TaskManager]
+
+      persistenceStore.persistJob(any[StoredJob]) answers { t =>
+        println("Storing: " + t)
+        Thread.currentThread().getStackTrace.foreach(elem => println(elem.toString))
+        true
+      }
 
       val scheduler = mockScheduler(epsilon, mockTaskManager, jobGraph, persistenceStore)
       val startTime = DateTime.parse("2012-01-01T01:00:00.000Z")
       scheduler.leader.set(true)
       scheduler.registerJob(job1, persist = true, startTime)
 
+      val nextInvocationTime = Schedule.parse("R4/2012-01-02T00:00:00.000Z/P1D").get.invocationTime
       val newStreams = scheduler.iteration(startTime, scheduler.streams)
-      newStreams.head.schedule must_== "R4/2012-01-02T00:00:00.000Z/P1D"
+      newStreams.head.schedule.invocationTime must_== nextInvocationTime
+      newStreams.head.schedule.recurrences must_== Some(4)
 
       scheduler.handleFailedTask(TaskUtils.getTaskStatus(job1, startTime, 0))
       scheduler.handleFailedTask(TaskUtils.getTaskStatus(job1, startTime, 0))
 
-      there was one(persistenceStore)
-        .persistJob(new ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD", epsilon))
-      there was one(persistenceStore)
-        .persistJob(new ScheduleBasedJob("R4/2012-01-02T00:00:00.000Z/P1D", "job1", "CMD", epsilon))
+      val jobCaptor = capture[InternalScheduleBasedJob]
+
+      there was two(persistenceStore)
+        .persistJob(jobCaptor)
+
+      val firstJob = jobCaptor.values.get(0)
+      val secondJob = jobCaptor.values.get(1)
+
+      firstJob must_== new InternalScheduleBasedJob(schedule, "job1", "CMD", epsilon)
+      secondJob must_== new InternalScheduleBasedJob(schedule.copy(invocationTime = nextInvocationTime, offset = 1, recurrences = Some(4)), "job1", "CMD", epsilon)
     }
 
     "Executing a job updates the job counts and errors" in {
       val epsilon = Minutes.minutes(20).toPeriod
       val jobName = "FOO"
-      val job1 = new ScheduleBasedJob(schedule = "R/2012-01-01T00:00:00.000Z/PT1M",
+      val job1 = new InternalScheduleBasedJob(scheduleData = Schedule.parse("R/2012-01-01T00:00:00.000Z/PT1M").get,
         name = jobName, command = "fooo", epsilon = epsilon, retries = 0)
 
       val horizon = Minutes.minutes(5).toPeriod
@@ -72,7 +87,8 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
 
     "Tests that a disabled job does not run and does not execute dependant children." in {
       val epsilon = Minutes.minutes(20).toPeriod
-      val job1 = new ScheduleBasedJob(schedule = "R/2012-01-01T00:00:00.000Z/PT1M",
+      val schedule = Schedule.parse("R/2012-01-01T00:00:00.000Z/PT1M").get
+      val job1 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job1", command = "fooo", epsilon = epsilon, disabled = true)
       val job2 = new DependencyBasedJob(Set("job1"), name = "job2", command = "CMD", disabled = true)
 
@@ -101,9 +117,11 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
 
     "Tests that dependent jobs runs when they should" in {
       val epsilon = Minutes.minutes(20).toPeriod
-      val job1 = new ScheduleBasedJob(schedule = "R/2012-01-01T00:00:00.000Z/PT1M",
+      val schedule = Schedule.parse("R/2012-01-01T00:00:00.000Z/PT1M").get
+
+      val job1 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job1", command = "fooo", epsilon = epsilon, disabled = false)
-      val job2 = new ScheduleBasedJob(schedule = "R/2012-01-01T00:00:00.000Z/PT1M",
+      val job2 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job2", command = "fooo", epsilon = epsilon, disabled = false)
 
       val job3 = new DependencyBasedJob(Set("job1"), name = "job3", command = "CMD", disabled = false)
@@ -159,9 +177,10 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
 
     "Tests that dependent jobs run even if their parents fail but have softError enabled" in {
       val epsilon = Minutes.minutes(20).toPeriod
-      val job1 = new ScheduleBasedJob(schedule = "R/2012-01-01T00:01:00.000Z/PT1M",
+      val schedule = Schedule.parse("R/2012-01-01T00:01:00.000Z/PT1M").get
+      val job1 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job1", command = "fooo", epsilon = epsilon, disabled = false)
-      val job2 = new ScheduleBasedJob(schedule = "R/2012-01-01T00:01:00.000Z/PT1M",
+      val job2 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job2", command = "fooo", epsilon = epsilon, disabled = false, retries = 0, softError = true)
 
       val job3 = new DependencyBasedJob(Set("job1", "job2"), name = "job3", command = "CMD", disabled = false)
@@ -203,9 +222,10 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
 
     "Tests that dependent jobs don't run if their parents fail without softError enabled" in {
       val epsilon = Minutes.minutes(20).toPeriod
-      val job1 = new ScheduleBasedJob(schedule = "R/2012-01-01T00:01:00.000Z/PT1M",
+      val schedule = Schedule.parse("R/2012-01-01T00:01:00.000Z/PT1M").get
+      val job1 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job1", command = "fooo", epsilon = epsilon, disabled = false)
-      val job2 = new ScheduleBasedJob(schedule = "R/2012-01-01T00:01:00.000Z/PT1M",
+      val job2 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job2", command = "fooo", epsilon = epsilon, disabled = false, retries = 0, softError = false)
 
       val job3 = new DependencyBasedJob(Set("job1", "job2"), name = "job3", command = "CMD", disabled = false)
@@ -242,9 +262,10 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
 
     "Tests that dependent jobs runs when they should after changing the jobgraph" in {
       val epsilon = Minutes.minutes(20).toPeriod
-      val job1 = new ScheduleBasedJob(schedule = "R/2012-01-01T00:01:00.000Z/PT1M",
+      val schedule = Schedule.parse("R/2012-01-01T00:01:00.000Z/PT1M").get
+      val job1 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job1", command = "fooo", epsilon = epsilon, disabled = false)
-      val job2 = new ScheduleBasedJob(schedule = "R/2012-01-01T00:01:00.000Z/PT1M",
+      val job2 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job2", command = "fooo", epsilon = epsilon, disabled = false)
 
       val job3 = new DependencyBasedJob(Set("job1"), name = "job3", command = "CMD", disabled = false)
@@ -336,9 +357,10 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
 
     "Tests that complex dependent jobs run when they should" in {
       val epsilon = Minutes.minutes(20).toPeriod
-      val job1 = new ScheduleBasedJob(schedule = "R/2012-01-01T00:00:00.000Z/PT1M",
+      val schedule = Schedule.parse("R/2012-01-01T00:00:00.000Z/PT1M").get
+      val job1 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job1", command = "fooo", epsilon = epsilon, disabled = false)
-      val job2 = new ScheduleBasedJob(schedule = "R/2012-01-01T00:00:00.000Z/PT1M",
+      val job2 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job2", command = "fooo", epsilon = epsilon, disabled = false)
 
       val job3 = new DependencyBasedJob(Set("job1"), name = "job3", command = "CMD", disabled = false)
@@ -417,9 +439,10 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
       val epsilon = Minutes.minutes(20).toPeriod
       val date = DateTime.now(DateTimeZone.UTC)
       val fmt = ISODateTimeFormat.dateTime()
-      val job1 = new ScheduleBasedJob(schedule = s"R/${fmt.print(date)}/PT1M",
+      val schedule = Schedule.parse(s"R/${fmt.print(date)}/PT1M").get
+      val job1 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job1", command = "fooo", epsilon = epsilon, disabled = false)
-      val job2 = new ScheduleBasedJob(schedule = s"R/${fmt.print(date)}/PT1M",
+      val job2 = new InternalScheduleBasedJob(scheduleData = schedule,
         name = "job2", command = "fooo", epsilon = epsilon, disabled = false)
 
       val job3 = new DependencyBasedJob(Set("job1"), name = "job3", command = "CMD", disabled = false)
@@ -474,8 +497,8 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
       graph.lookupVertex("job5").get.errorCount must_== 0
 
       val jobResource = new Iso8601JobResource(jobScheduler = scheduler, jobGraph = graph)
-      jobResource.handleRequest(job1)
-      jobResource.handleRequest(job2)
+      jobResource.handleRequest(JobUtils.convertInternalScheduleToExternalScheduled(job1))
+      jobResource.handleRequest(JobUtils.convertInternalScheduleToExternalScheduled(job2))
 
       scheduler.run(() => {
         date

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerIntegrationTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerIntegrationTest.scala
@@ -21,12 +21,6 @@ class JobSchedulerIntegrationTest extends SpecificationWithJUnit with Mockito {
       val persistenceStore = mock[PersistenceStore]
       val mockTaskManager = mock[TaskManager]
 
-      persistenceStore.persistJob(any[StoredJob]) answers { t =>
-        println("Storing: " + t)
-        Thread.currentThread().getStackTrace.foreach(elem => println(elem.toString))
-        true
-      }
-
       val scheduler = mockScheduler(epsilon, mockTaskManager, jobGraph, persistenceStore)
       val startTime = DateTime.parse("2012-01-01T01:00:00.000Z")
       scheduler.leader.set(true)

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerSpec.scala
@@ -263,22 +263,21 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     there was one(mockGraph).replaceVertex(job1, job2)
   }
 
-  //todo: re-enable after hearing back from chronos guys
-//  "Missed executions have to be skipped" in {
-//    val epsilon = Seconds.seconds(60).toPeriod
-//    val job1 = new InternalScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD", epsilon)
-//
-//    val mockTaskManager = mock[TaskManager]
-//    val jobGraph = new JobGraph
-//    val mockPersistenceStore = mock[PersistenceStore]
-//
-//    val scheduler = mockScheduler(epsilon, mockTaskManager, jobGraph, mockPersistenceStore)
-//
-//    val startTime = DateTime.parse("2012-01-03T00:00:00.000Z")
-//    scheduler.leader.set(true)
-//    scheduler.registerJob(job1, persist = true, startTime)
-//
-//    val newStreams = scheduler.iteration(startTime, scheduler.streams)
-//    newStreams.head.schedule must_== "R2/2012-01-04T00:00:00.000Z/P1D"
-//  }
+  "Missed executions have to be skipped" in {
+    val epsilon = Seconds.seconds(60).toPeriod
+    val job1 = new InternalScheduleBasedJob(Schedule.parse("R5/2012-01-01T00:00:00.000Z/P1D").get, "job1", "CMD", epsilon)
+
+    val mockTaskManager = mock[TaskManager]
+    val jobGraph = new JobGraph
+    val mockPersistenceStore = mock[PersistenceStore]
+
+    val scheduler = mockScheduler(epsilon, mockTaskManager, jobGraph, mockPersistenceStore)
+
+    val startTime = DateTime.parse("2012-01-03T00:00:00.000Z")
+    scheduler.leader.set(true)
+    scheduler.registerJob(job1, persist = true, startTime)
+
+    val newStreams = scheduler.iteration(startTime, scheduler.streams)
+    newStreams.head.schedule.invocationTime must_== Schedule.parse("R2/2012-01-04T00:00:00.000Z/P1D").get.invocationTime
+  }
 }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerSpec.scala
@@ -14,9 +14,10 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     "Construct a task for a given time when the schedule is within epsilon" in {
       val epsilon = Minutes.minutes(1).toPeriod
       val jobName = "FOO"
-      val job1 = new ScheduleBasedJob(schedule = "", name = jobName, command = "", epsilon = epsilon)
+      val schedule = Schedule.parse("R1/2012-01-01T00:00:01.000Z/PT1M").get
 
-      val singleJobStream = new ScheduleStream("R1/2012-01-01T00:00:01.000Z/PT1M", jobName)
+      val job1 = new InternalScheduleBasedJob(scheduleData = schedule, name = jobName, command = "", epsilon = epsilon)
+      val singleJobStream = new ScheduleStream(jobName, schedule)
 
       val mockGraph = mock[JobGraph]
       mockGraph.lookupVertex(jobName).returns(Some(job1))
@@ -34,9 +35,10 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     "Ignore a task that has been due past epsilon" in {
       val epsilon = Minutes.minutes(1).toPeriod
       val jobName = "FOO"
-      val job1 = new ScheduleBasedJob(schedule = "", name = jobName, command = "", epsilon = epsilon)
+      val schedule = Schedule.parse("R1/2012-01-01T00:00:01.000Z/PT1M").get
 
-      val singleJobStream = new ScheduleStream("R1/2012-01-01T00:00:01.000Z/PT1M", jobName)
+      val job1 = new InternalScheduleBasedJob(scheduleData = schedule, name = jobName, command = "", epsilon = epsilon)
+      val singleJobStream = new ScheduleStream(jobName, schedule)
 
       val mockGraph = mock[JobGraph]
       mockGraph.lookupVertex(jobName).returns(Some(job1))
@@ -51,9 +53,10 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     "Get an empty stream if no-op schedule is given" in {
       val epsilon = Minutes.minutes(1).toPeriod
       val jobName = "FOO"
-      val job1 = new ScheduleBasedJob(schedule = "", name = jobName, command = "", epsilon = epsilon)
+      val schedule: Schedule = Schedule.parse("R0/2012-01-01T00:00:01.000Z/PT1M").get
+      val job1 = new InternalScheduleBasedJob(scheduleData = schedule, name = jobName, command = "", epsilon = epsilon)
 
-      val singleJobStream = new ScheduleStream("R0/2012-01-01T00:00:01.000Z/PT1M", jobName)
+      val singleJobStream = new ScheduleStream(jobName, schedule)
 
       val mockGraph = mock[JobGraph]
       mockGraph.lookupVertex(jobName).returns(Some(job1))
@@ -68,12 +71,13 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     "Old schedule stream is removed" in {
       val epsilon = Minutes.minutes(1).toPeriod
       val jobName = "FOO"
-      val job1 = new ScheduleBasedJob(schedule = "", name = jobName, command = "", epsilon = epsilon)
+      val schedule: Schedule = Schedule.parse("R1/2012-01-01T00:00:01.000Z/PT1M").get
 
+      val job1 = new InternalScheduleBasedJob(scheduleData = schedule, name = jobName, command = "", epsilon = epsilon)
       val mockGraph = mock[JobGraph]
       mockGraph.lookupVertex(jobName).returns(Some(job1))
 
-      val singleJobStream = new ScheduleStream("R1/2012-01-01T00:00:01.000Z/PT1M", jobName)
+      val singleJobStream = new ScheduleStream(jobName, schedule)
 
       val horizon = Minutes.minutes(10).toPeriod
       val scheduler = mockScheduler(horizon, null, mockGraph)
@@ -85,10 +89,11 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     "Old schedule streams are removed but newer ones are kept" in {
       val epsilon = Seconds.seconds(20).toPeriod
       val jobName = "FOO"
-      val job1 = new ScheduleBasedJob(schedule = "", name = jobName, command = "", epsilon = epsilon)
+      val schedule: Schedule = Schedule.parse("R10/2012-01-01T00:00:00.000Z/PT1M").get
 
+      val job1 = new InternalScheduleBasedJob(scheduleData = schedule, name = jobName, command = "", epsilon = epsilon)
       //2012-01-01T00:00:00.000 -> 2012-01-01T00:09:00.000
-      val jobStream = new ScheduleStream("R10/2012-01-01T00:00:00.000Z/PT1M", jobName)
+      val jobStream = new ScheduleStream(jobName, schedule)
       // 1st planned invocation @ 2012-01-01T00:00:00.000Z (missed)
       // 2nd planned invocation @ 2012-01-01T00:01:00.000Z (executed)
       // 3rd planned invocation @ 2012-01-01T00:02:00.000Z (scheduled)
@@ -108,15 +113,9 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
       // First one passed, next invocation is 01:01 (b/c of 20 second epsilon)
       // Horizon is 5 minutes, so lookforward until 00:06:01.000Z
       val newScheduleStreams = scheduler.iteration(DateTime.parse("2012-01-01T00:01:01.000Z"), List(jobStream))
-      val (isoExpr, _, _) = newScheduleStreams.head.head
+      val (newJobName, newSchedule) = newScheduleStreams.head.head
 
-      var date: DateTime = new DateTime()
-      Iso8601Expressions.parse(isoExpr) match {
-        case Some((_, d, _)) =>
-          date = d
-        case None =>
-      }
-      date must_== DateTime.parse("2012-01-01T00:07:00.000Z")
+      newSchedule.invocationTime must_== DateTime.parse("2012-01-01T00:07:00.000Z")
 
       there were 6.times(mockTaskManager).scheduleDelayedTask(any[ScheduledTask], anyLong, any[Boolean])
     }
@@ -124,9 +123,10 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     "Future task beyond time-horizon should not be scheduled" in {
       val epsilon = Seconds.seconds(60).toPeriod
       val jobName = "FOO"
-      val job1 = new ScheduleBasedJob(schedule = "", name = jobName, command = "", epsilon = epsilon)
+      val schedule: Schedule = Schedule.parse("R10/2012-01-10T00:00:00.000Z/PT1M").get
+      val job1 = new InternalScheduleBasedJob(scheduleData = schedule, name = jobName, command = "", epsilon = epsilon)
 
-      val jobStream = new ScheduleStream("R10/2012-01-10T00:00:00.000Z/PT1M", jobName)
+      val jobStream = new ScheduleStream(jobName, schedule)
 
       val mockGraph = mock[JobGraph]
       mockGraph.lookupVertex(jobName).returns(Some(job1))
@@ -134,23 +134,17 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
       val horizon = Minutes.minutes(60).toPeriod
       val scheduler = mockScheduler(horizon, null, mockGraph)
       val newScheduleStreams = scheduler.iteration(DateTime.parse("2012-01-01T00:01:01.000Z"), List(jobStream))
-      val (isoExpr, _, _) = newScheduleStreams.head.head
+      val (newJobName, newSchedule) = newScheduleStreams.head.head
 
-      var date: DateTime = new DateTime()
-      Iso8601Expressions.parse(isoExpr) match {
-        case Some((_, d, _)) =>
-          date = d
-        case None =>
-      }
-      date must_== DateTime.parse("2012-01-10T00:00:00.000Z")
-
+      newSchedule.invocationTime must_== DateTime.parse("2012-01-10T00:00:00.000Z")
     }
 
     "Multiple tasks must be scheduled if they're within epsilon and before time-horizon" in {
       val epsilon = Minutes.minutes(5).toPeriod
       val jobName = "FOO"
-      val job1 = new ScheduleBasedJob(schedule = "", name = jobName, command = "", epsilon = epsilon)
-      val jobStream = new ScheduleStream("R60/2012-01-01T00:00:00.000Z/PT1S", jobName)
+      val schedule: Schedule = Schedule.parse("R60/2012-01-01T00:00:00.000Z/PT1S").get
+      val job1 = new InternalScheduleBasedJob(scheduleData = schedule, name = jobName, command = "", epsilon = epsilon)
+      val jobStream = new ScheduleStream(jobName, schedule)
 
       val mockGraph = mock[JobGraph]
       mockGraph.lookupVertex(jobName).returns(Some(job1))
@@ -168,10 +162,11 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     "Infinite task must be scheduled" in {
       val epsilon = Seconds.seconds(60).toPeriod
       val jobName = "FOO"
-      val job1 = new ScheduleBasedJob(schedule = "", name = jobName, command = "", epsilon = epsilon)
+      val schedule: Schedule = Schedule.parse("R/2012-01-01T00:00:00.000Z/PT1M").get
+      val job1 = new InternalScheduleBasedJob(scheduleData = schedule, name = jobName, command = "", epsilon = epsilon)
 
 
-      val jobStream = new ScheduleStream("R/2012-01-01T00:00:00.000Z/PT1M", jobName)
+      val jobStream = new ScheduleStream(jobName, schedule)
 
       val horizon = Seconds.seconds(30).toPeriod
       val mockTaskManager = mock[TaskManager]
@@ -213,8 +208,9 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
 
   "Removing tasks must also remove the streams" in {
     val epsilon = Seconds.seconds(60).toPeriod
-    val job1 = new ScheduleBasedJob("R/2012-01-01T00:00:00.000Z/PT1M", "FOO", "CMD", epsilon)
-    val job2 = new ScheduleBasedJob("R/2012-01-01T00:00:00.000Z/PT1M", "BAR", "CMD", epsilon)
+    val schedule = Schedule.parse("R/2012-01-01T00:00:00.000Z/PT1M").get
+    val job1 = new InternalScheduleBasedJob(schedule, "FOO", "CMD", epsilon)
+    val job2 = new InternalScheduleBasedJob(schedule, "BAR", "CMD", epsilon)
 
     val horizon = Seconds.seconds(30).toPeriod
     val mockTaskManager = mock[TaskManager]
@@ -247,11 +243,12 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     val jobName = "FOO"
     val jobCmd = "BARCMD"
 
-    val job1 = new ScheduleBasedJob("R/2012-01-01T00:00:00.000Z/PT1S", jobName, jobCmd, epsilon)
+    val schedule = Schedule.parse("R/2012-01-01T00:00:00.000Z/PT1S").get
+    val job1 = new InternalScheduleBasedJob(schedule, jobName, jobCmd, epsilon)
     val mockGraph = mock[JobGraph]
     mockGraph.lookupVertex(job1.name).returns(Some(job1))
 
-    val jobStream = new ScheduleStream("R/2012-01-01T00:00:00.000Z/PT1S", jobName)
+    val jobStream = new ScheduleStream(jobName, Schedule.parse("R/2012-01-01T00:00:00.000Z/PT1S").get)
     val scheduler = mockScheduler(Period.hours(1), mock[TaskManager], mockGraph, store)
     scheduler.leader.set(true)
 
@@ -260,26 +257,28 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     var stream = scheduler.iteration(startTime, List(jobStream))
     t = t.plus(Period.millis(1).toPeriod)
     stream = scheduler.iteration(t, stream)
-    val job2 = new ScheduleBasedJob("R/2012-01-01T00:00:01.000Z/PT1S", jobName, jobCmd, epsilon, 0)
+    val nextSchedule: Schedule = schedule.copy(invocationTime = schedule.invocationTime.plus(schedule.period), offset = schedule.offset + 1)
+    val job2 = new InternalScheduleBasedJob(nextSchedule, jobName, jobCmd, epsilon, 0)
     there was one(store).persistJob(job2)
     there was one(mockGraph).replaceVertex(job1, job2)
   }
 
-  "Missed executions have to be skipped" in {
-    val epsilon = Seconds.seconds(60).toPeriod
-    val job1 = new ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD", epsilon)
-
-    val mockTaskManager = mock[TaskManager]
-    val jobGraph = new JobGraph
-    val mockPersistenceStore = mock[PersistenceStore]
-
-    val scheduler = mockScheduler(epsilon, mockTaskManager, jobGraph, mockPersistenceStore)
-
-    val startTime = DateTime.parse("2012-01-03T00:00:00.000Z")
-    scheduler.leader.set(true)
-    scheduler.registerJob(job1, persist = true, startTime)
-
-    val newStreams = scheduler.iteration(startTime, scheduler.streams)
-    newStreams.head.schedule must_== "R2/2012-01-04T00:00:00.000Z/P1D"
-  }
+  //todo: re-enable after hearing back from chronos guys
+//  "Missed executions have to be skipped" in {
+//    val epsilon = Seconds.seconds(60).toPeriod
+//    val job1 = new InternalScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD", epsilon)
+//
+//    val mockTaskManager = mock[TaskManager]
+//    val jobGraph = new JobGraph
+//    val mockPersistenceStore = mock[PersistenceStore]
+//
+//    val scheduler = mockScheduler(epsilon, mockTaskManager, jobGraph, mockPersistenceStore)
+//
+//    val startTime = DateTime.parse("2012-01-03T00:00:00.000Z")
+//    scheduler.leader.set(true)
+//    scheduler.registerJob(job1, persist = true, startTime)
+//
+//    val newStreams = scheduler.iteration(startTime, scheduler.streams)
+//    newStreams.head.schedule must_== "R2/2012-01-04T00:00:00.000Z/P1D"
+//  }
 }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/ScheduleStreamSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/ScheduleStreamSpec.scala
@@ -9,21 +9,61 @@ class ScheduleStreamSpec extends SpecificationWithJUnit {
 
   "ScheduleStream" should {
     "return a properly clipped schedule" in {
-      val orgSchedule = "R3/2012-01-01T00:00:00.000Z/P1D"
-      val stream = new ScheduleStream(orgSchedule, null)
-      stream.head must_==(orgSchedule, null, "")
-      stream.tail.get.head must_==("R2/2012-01-02T00:00:00.000Z/P1D", null, "")
-      stream.tail.get.tail.get.head must_==("R1/2012-01-03T00:00:00.000Z/P1D", null, "")
-      stream.tail.get.tail.get.tail.get.head must_==("R0/2012-01-04T00:00:00.000Z/P1D", null, "")
-      stream.tail.get.tail.get.tail.get.tail must_== None
+      val orgSchedule = Schedule.parse("R3/2012-01-01T00:00:00.000Z/P1D").get
+      val stream = new ScheduleStream(null, orgSchedule)
+      stream.head must_== (null, orgSchedule)
+
+      val nextSchedule = stream.tail.get.head._2
+      nextSchedule.invocationTime must_== Schedule.parse("R2/2012-01-02T00:00:00.000Z/P1D").get.invocationTime
+      nextSchedule.offset must_== 1
+      nextSchedule.recurrences must_== Some(2)
+
+      val nextSchedule2 = stream.tail.get.tail.get.head._2
+      nextSchedule2.invocationTime must_== Schedule.parse("R1/2012-01-03T00:00:00.000Z/P1D").get.invocationTime
+      nextSchedule2.offset must_== 2
+      nextSchedule2.recurrences must_== Some(1)
+
+      val nextSchedule3 = stream.tail.get.tail.get.tail.get.head._2
+      nextSchedule3.invocationTime must_== Schedule.parse("R0/2012-01-04T00:00:00.000Z/P1D").get.invocationTime
+      nextSchedule3.offset must_== 3
+      nextSchedule3.recurrences must_== Some(0)
+
+      nextSchedule3.next must_== None
     }
 
     "return a infinite schedule when no repetition is specified" in {
-      val orgSchedule = "R/2012-01-01T00:00:00.000Z/P1D"
-      val stream = new ScheduleStream(orgSchedule, null)
-      stream.head must_==(orgSchedule, null, "")
-      stream.tail.get.head must_==("R/2012-01-02T00:00:00.000Z/P1D", null, "")
+      val orgSchedule = Schedule.parse("R/2012-01-01T00:00:00.000Z/P1D").get
+      val stream = new ScheduleStream(null, orgSchedule)
+      val infiniteSchedule = stream.head._2
+      infiniteSchedule.invocationTime must_== orgSchedule.invocationTime
+      infiniteSchedule.recurrences must_== None
+
+      stream.tail.get.head._2.invocationTime must_== Schedule.parse("R/2012-01-02T00:00:00.000Z/P1D").get.invocationTime
+    }
+
+    "be convertible back to a string for simple cases" in {
+      val orgSchedule = new ScheduleStream(null, Schedule.parse("R/2012-01-01T00:00:00.000Z/P1D").get)
+      val newSchedule = orgSchedule.tail.get.tail.get.head._2
+
+      newSchedule.toZeroOffsetISO8601Representation must_== "R/2012-01-03T00:00:00.000Z/P1D"
+    }
+
+    "handle variable length months repetition correctly" in {
+      val orgSchedule = Schedule.parse("R/2012-01-31T00:00:00.000Z/P1M").get
+      val stream = new ScheduleStream(null, orgSchedule)
+
+      val nextSchedule = stream.tail.get.head._2
+      nextSchedule.invocationTime must_== Schedule.parse("R/2012-02-29T00:00:00.000Z/P1M").get.invocationTime
+      nextSchedule.offset must_== 1
+      nextSchedule.recurrences must_== None
+
+      val nextSchedule2 = stream.tail.get.tail.get.head._2
+      nextSchedule2.invocationTime must_== Schedule.parse("R/2012-03-31T00:00:00.000Z/P1M").get.invocationTime
+      nextSchedule2.offset must_== 2
+
+      val nextSchedule3 = stream.tail.get.tail.get.tail.get.head._2
+      nextSchedule3.invocationTime must_== Schedule.parse("R/2012-04-30T00:00:00.000Z/P1M").get.invocationTime
+      nextSchedule3.offset must_== 3
     }
   }
-
 }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManagerSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManagerSpec.scala
@@ -31,7 +31,7 @@ class TaskManagerSpec extends SpecificationWithJUnit with Mockito {
         mockJobGraph, null, MockJobUtils.mockFullObserver, mock[MetricRegistry], makeConfig(),
         mock[MesosOfferReviver])
 
-      val job = new ScheduleBasedJob("R/2012-01-01T00:00:01.000Z/PT1M", "test", "sample-command")
+      val job = new InternalScheduleBasedJob(Schedule.parse("R/2012-01-01T00:00:01.000Z/PT1M").get, "test", "sample-command")
 
       mockJobGraph.lookupVertex("test").returns(Some(job)) // so we can enqueue a job.
       taskManager.enqueue("ct:1420843781398:0:test:", highPriority = true)
@@ -52,7 +52,7 @@ class TaskManagerSpec extends SpecificationWithJUnit with Mockito {
       val taskManager = new TaskManager(mock[ListeningScheduledExecutorService], mockPersistencStore,
         mockJobGraph, null, MockJobUtils.mockFullObserver, mock[MetricRegistry], config, mockMesosOfferReviver)
 
-      val job = new ScheduleBasedJob("R/2012-01-01T00:00:01.000Z/PT1M", "test", "sample-command")
+      val job = new InternalScheduleBasedJob(Schedule.parse("R/2012-01-01T00:00:01.000Z/PT1M").get, "test", "sample-command")
       mockJobGraph.lookupVertex("test").returns(Some(job)) // so we can enqueue a job.
 
       taskManager.enqueue("ct:1420843781398:0:test:", highPriority = true)
@@ -69,7 +69,7 @@ class TaskManagerSpec extends SpecificationWithJUnit with Mockito {
       val taskManager = new TaskManager(mock[ListeningScheduledExecutorService], mockPersistencStore,
         mockJobGraph, null, MockJobUtils.mockFullObserver, mock[MetricRegistry], config, mockMesosOfferReviver)
 
-      val job = new ScheduleBasedJob("R/2012-01-01T00:00:01.000Z/PT1M", "test", "sample-command")
+      val job = new InternalScheduleBasedJob(Schedule.parse("R/2012-01-01T00:00:01.000Z/PT1M").get, "test", "sample-command")
       mockJobGraph.lookupVertex("test").returns(Some(job)) // so we can enqueue a job.
 
       taskManager.enqueue("ct:1420843781398:0:test:", highPriority = true)

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/state/PersistenceStoreSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/state/PersistenceStoreSpec.scala
@@ -11,8 +11,8 @@ class PersistenceStoreSpec extends SpecificationWithJUnit with Mockito {
 
     "Writing and reading ScheduledBasedJob a job works" in {
       val store = new MesosStatePersistenceStore(null, null)
-      val startTime = "R1/2012-01-01T00:00:01.000Z/PT1M"
-      val job = new ScheduleBasedJob(schedule = startTime, name = "sample-name",
+      val schedule = Schedule.parse("R1/2012-01-01T00:00:01.000Z/PT1M").get
+      val job = new InternalScheduleBasedJob(scheduleData = schedule, name = "sample-name",
         command = "sample-command", successCount = 1L, epsilon = Hours.hours(1).toPeriod,
         executor = "fooexecutor", executorFlags = "args")
 
@@ -28,9 +28,9 @@ class PersistenceStoreSpec extends SpecificationWithJUnit with Mockito {
 
     "Writing and reading DependencyBasedJob a job works" in {
       val store = new MesosStatePersistenceStore(null, null)
-      val startTime = "R1/2012-01-01T00:00:01.000Z/PT1M"
+      val schedule = Schedule.parse("R1/2012-01-01T00:00:01.000Z/PT1M").get
       val epsilon = Hours.hours(1).toPeriod
-      val schedJob = new ScheduleBasedJob(schedule = startTime, name = "sample-name",
+      val schedJob = new InternalScheduleBasedJob(scheduleData = schedule, name = "sample-name",
         command = "sample-command", epsilon = epsilon)
       val job = new DependencyBasedJob(parents = Set("sample-name"),
         name = "sample-dep", command = "sample-command",


### PR DESCRIPTION
- Revised scheduling to store a schedule data structure rather than a string
- Month-end behavior now works as expected
- No external interface changes
- Existing original-style jobs should be converted on the first load and persist

In order to keep the external API the same and handle backwards compatibility with persisted jobs, the original scheduled job type is still there. InternalScheduleBasedJob was added to address all of the areas where jobs are referenced in memory.

Also removed unnecessary handling of arbitrary types by ensuring that types are sealed, and enabling -Xfatal-warnings to have warnings (non-exhaustive match, etc.)
