### PR TITLE
tweaks to dockerfile and run script to facilitate alternate launch strategy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ADD . /chronos
 
 WORKDIR /chronos
 
-RUN mvn clean package
+RUN mvn clean package -DskipTests
 
 EXPOSE 8080
 

--- a/bin/chronos-marathon
+++ b/bin/chronos-marathon
@@ -9,7 +9,7 @@ export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-/lib}"
 export LD_LIBRARY_PATH="$JAVA_LIBRARY_PATH:$LD_LIBRARY_PATH"
 export PORT0="${PORT0:-8080}"
 
-flags=()
+flags=( $@ )
 
 #If we're on Amazon, let's use the public hostname so redirect works as expected.
 if public_hostname="$( curl -sSf --connect-timeout 1 http://169.254.169.254/latest/meta-data/public-hostname )"
@@ -22,15 +22,16 @@ fi
 jar_files=( "$chronos_home"/target/chronos*.jar )
 echo "Using jar file: $jar_files[0]"
 
-# This assumes there is a file, /etc/mesos/zk that contains the ZK string.
-mesos_master="$( < /etc/mesos/zk)"
+# MESOS_MASTER variable or assuming there is a file, /etc/mesos/zk, that contains the ZK string
+mesos_master="${MESOS_MASTER:-$( < /etc/mesos/zk)}"
+
 tmp="${mesos_master//zk:\/\/}"
 zk_hosts="${tmp/\/*}"
 
 flags+=( --master $mesos_master
          --zk_hosts $zk_hosts )
 
-heap=384m
+heap=${JVM_HEAP:-384m}
 
 java -Xmx"$heap" -Xms"$heap" -cp "${jar_files[0]}" \
      org.apache.mesos.chronos.scheduler.Main \


### PR DESCRIPTION
in my recent efforts working on a pull-request, i found it convenient to use `docker build` against the local `Dockerfile` to generate an image which i could subsequently reference in a marathon job along with the `bin/chronos-marathon` script to launch/evaluate a "SNAPSHOT" version of chronos in a mesos cluster.

there were a few things i needed to change to accomplish this:

(1) skip the tests in the maven directive per (https://github.com/mesos/chronos/issues/570)
(2) override a couple of default variables
(3) pass some additional command line parameters

this p/r encompasses those changes.

i didn't have the where-with-all to fix the existing test failures when running `docker build`, they are likely just environmental because it looks like the tests are succeeding in travis per the github hooks.

so i'm thinking it might be acceptable to skip tests when running `docker build`. 

if this is not the case, i can remove that commit if someone can get the tests to run within `docker build`.
