### PR TITLE
Fix #544 command is required for docker containers

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosTaskBuilder.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosTaskBuilder.scala
@@ -101,8 +101,18 @@ class MesosTaskBuilder @Inject()(val conf: SchedulerConfiguration) {
             .setValue(uri)
             .build()
         })
-        command.setValue(job.command)
-          .setShell(job.shell)
+
+        Option(job.command) match {
+          case Some(cmd) if ! cmd.isEmpty =>
+            command.setValue(cmd)
+                   .setShell(job.shell)
+          case _ =>
+            // This typically hapens when the user want to execute the command in a container,
+            // in this situation we don't need a shell.
+            command.setShell(false)
+        }
+
+        command
           .setEnvironment(environment)
           .addAllArguments(job.arguments.asJava)
           .addAllUris(uriProtos.asJava)

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
@@ -29,7 +29,11 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
     val node = codec.readTree[JsonNode](jsonParser)
 
     val name = node.get("name").asText
-    val command = node.get("command").asText
+
+    val command =
+      if (node.has("command") && node.get("command") != null) node.get("command").asText
+      else ""
+
     val shell =
       if (node.has("shell") && node.get("shell") != null) node.get("shell").asBoolean
       else true


### PR DESCRIPTION
This commit makes 'command' an optional field.

I opted out of doing any other validation as a consequence of this, i.e. raising an exception if neither the command field nor container object is set. Thoughts on this?

Furthermore I looked at how Marathon handled shells and commands, and did something similar - i.e. disabled shell implicitly when a command is not given. Open for alternative approaches to this too.

Edit: If we wanted to do validation (i.e. checking that you had either 'container' or 'command' set) I guess we could do that the same place we validate the 'name' field - that is in `scheduler/api/Iso8601JobResource.scala`
