### PR TITLE
add unlikeconstraint

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -416,5 +416,19 @@ Schedule jobs on nodes which attributes match a regular expression.
 
 **Note:** This constraint applies to attributes of type `text` and `scalar` and elements in a `set`, but not `range`.
 
+### UNLIKE constraint
+
+Schedule jobs on nodes which attributes *do not* match a regular expression.
+
+```json
+{
+  ...
+  "constraints": [["rack", "UNLIKE", "rack-[1-3]"]],
+  ...
+}
+```
+
+**Note:** This constraint applies to attributes of type `text` and `scalar` and elements in a `set`, but not `range`.
+
 [json]: http://www.json.org/
 [ISO 8601]: https://en.wikipedia.org/wiki/ISO_8601

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/UnlikeConstraint.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/UnlikeConstraint.scala
@@ -1,0 +1,37 @@
+package org.apache.mesos.chronos.scheduler.jobs.constraints
+
+import java.util.logging.Logger
+
+import org.apache.mesos.Protos
+import scala.collection.JavaConversions._
+
+case class UnlikeConstraint(attribute: String, value: String) extends Constraint {
+
+  val regex = value.r
+
+  private[this] val log = Logger.getLogger(getClass.getName)
+
+  def matches(attributes: Seq[Protos.Attribute]): Boolean = {
+    attributes.find(a => a.getName == attribute).exists { a =>
+      a.getType match {
+        case Protos.Value.Type.SCALAR =>
+          !regex.pattern.matcher(a.getScalar.getValue.toString).matches()
+        case Protos.Value.Type.SET =>
+          !a.getSet.getItemList.exists(regex.pattern.matcher(_).matches())
+        case Protos.Value.Type.TEXT =>
+          !regex.pattern.matcher(a.getText.getValue).matches()
+        case Protos.Value.Type.RANGES =>
+          log.warning("Unlike constraint does not support attributes of type RANGES")
+          false
+        case _ =>
+          val t = a.getType.getNumber
+          log.warning(s"Unknown constraint with number $t in Unlike constraint")
+          false
+      }
+    }
+  }
+}
+
+object UnlikeConstraint {
+  val OPERATOR = "UNLIKE"
+}

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
@@ -191,6 +191,8 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
             constraints.add(EqualsConstraint(c.get(0).asText, c.get(2).asText))
           case LikeConstraint.OPERATOR =>
             constraints.add(LikeConstraint(c.get(0).asText, c.get(2).asText))
+          case UnlikeConstraint.OPERATOR =>
+            constraints.add(UnlikeConstraint(c.get(0).asText, c.get(2).asText))
           case _ =>
         }
       }

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobSerializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobSerializer.scala
@@ -1,7 +1,7 @@
 package org.apache.mesos.chronos.utils
 
 import org.apache.mesos.chronos.scheduler.jobs.{BaseJob, DependencyBasedJob, ScheduleBasedJob}
-import org.apache.mesos.chronos.scheduler.jobs.constraints.{LikeConstraint, EqualsConstraint}
+import org.apache.mesos.chronos.scheduler.jobs.constraints.{LikeConstraint, EqualsConstraint, UnlikeConstraint}
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.{JsonSerializer, SerializerProvider}
 
@@ -164,6 +164,10 @@ class JobSerializer extends JsonSerializer[BaseJob] {
         case LikeConstraint(attribute, value) =>
           json.writeString(attribute)
           json.writeString(LikeConstraint.OPERATOR)
+          json.writeString(value)
+        case UnlikeConstraint(attribute, value) =>
+          json.writeString(attribute)
+          json.writeString(UnlikeConstraint.OPERATOR)
           json.writeString(value)
       }
       json.writeEndArray()

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/api/SerDeTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/api/SerDeTest.scala
@@ -1,6 +1,6 @@
 package org.apache.mesos.chronos.scheduler.api
 
-import org.apache.mesos.chronos.scheduler.jobs.constraints.{LikeConstraint, EqualsConstraint}
+import org.apache.mesos.chronos.scheduler.jobs.constraints.{LikeConstraint, EqualsConstraint, UnlikeConstraint}
 import org.apache.mesos.chronos.scheduler.jobs.{DependencyBasedJob, DockerContainer, EnvironmentVariable, ScheduleBasedJob, _}
 import org.apache.mesos.chronos.utils.{JobDeserializer, JobSerializer}
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -40,7 +40,8 @@ class SerDeTest extends SpecificationWithJUnit {
 
       val constraints = Seq(
         EqualsConstraint("rack", "rack-1"),
-        LikeConstraint("rack", "rack-[1-3]")
+        LikeConstraint("rack", "rack-[1-3]"),
+        UnlikeConstraint("host", "foo")
       )
 
       val a = new DependencyBasedJob(Set("B", "C", "D", "E"), "A", "noop", Minutes.minutes(5).toPeriod, 10L,
@@ -82,7 +83,8 @@ class SerDeTest extends SpecificationWithJUnit {
 
       val constraints = Seq(
         EqualsConstraint("rack", "rack-1"),
-        LikeConstraint("rack", "rack-[1-3]")
+        LikeConstraint("rack", "rack-[1-3]"),
+        UnlikeConstraint("host", "foo")
       )
 
       val a = new ScheduleBasedJob("FOO/BAR/BAM", "A", "noop", Minutes.minutes(5).toPeriod, 10L, 20L,

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/UnlikeConstraintSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/constraints/UnlikeConstraintSpec.scala
@@ -1,0 +1,47 @@
+package org.apache.mesos.chronos.scheduler.jobs.constraints
+
+import java.util.regex.PatternSyntaxException
+
+import org.specs2.mutable.SpecificationWithJUnit
+
+class UnlikeConstraintSpec extends SpecificationWithJUnit
+  with ConstraintSpecHelper {
+  "matches attributes of type text" in {
+    val attributes = List(createTextAttribute("dc", "north"), createTextAttribute("rack", "rack-4"))
+    val constraint = UnlikeConstraint("rack", "rack-[1-3]")
+
+    constraint.matches(attributes) must_== true
+
+    val attributes2 = List(createTextAttribute("dc", "north"))
+    val constraint2 = UnlikeConstraint("dc", "north|south")
+
+    constraint2.matches(attributes2) must_== false
+  }
+
+  "matches attributes of type scalar" in {
+    val attributes = List(createScalarAttribute("number", 1))
+    val constraint = UnlikeConstraint("number", """\d\.\d""")
+
+    constraint.matches(attributes) must_== false
+
+    val attributes2 = List(createScalarAttribute("number", 1))
+    val constraint2 = UnlikeConstraint("number", """100.\d""")
+    constraint2.matches(attributes) must_== true
+
+  }
+
+  "matches attributes of type set" in {
+    val attributes = List(createSetAttribute("dc", Array("north")))
+    val constraint = UnlikeConstraint("dc", "^n.*")
+
+    constraint.matches(attributes) must_== false
+
+    val attributes2 = List(createSetAttribute("dc", Array("south")))
+
+    constraint.matches(attributes2) must_== true
+  }
+
+  "fails in case of an invalid regular expression" in {
+    UnlikeConstraint("invalid-regex", "[[[") must throwA[PatternSyntaxException]
+  }
+}


### PR DESCRIPTION
Marathon supports [UnlikeConstraints](https://mesosphere.github.io/marathon/docs/constraints.html) to run tasks on slaves *not* matching a given attribute.

This adds the equivalent to Chronos. Most of this has been c+p from the LikeConstraint class, with the case conditions negated in the matches() function of the Constraint.

Warning: I don't have any prior experience writing Scala, so I'm open to ideas for cleaning this up. The range constraint has been left unimplemented as in the LikeConstraint.