### PR TITLE
Adding statistics backend for webhook

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/Main.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/Main.scala
@@ -19,7 +19,7 @@ import org.rogach.scallop.ScallopConf
 object Main extends App {
   lazy val conf = new ScallopConf(args)
     with HttpConf with AppConfiguration with SchedulerConfiguration
-    with GraphiteConfiguration with CassandraConfiguration
+    with GraphiteConfiguration with CassandraConfiguration with StatsPublisherConfiguration
   val isLeader = new AtomicBoolean(false)
   private[this] val log = Logger.getLogger(getClass.getName)
 

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/config/JobStatsModule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/config/JobStatsModule.scala
@@ -6,7 +6,7 @@ import com.datastax.driver.core.policies.{DowngradingConsistencyRetryPolicy, Lat
 import com.google.inject.{AbstractModule, Provides, Scopes, Singleton}
 import org.apache.mesos.chronos.scheduler.jobs.stats.JobStats
 
-class JobStatsModule(config: CassandraConfiguration) extends AbstractModule {
+class JobStatsModule(config: CassandraConfiguration with StatsPublisherConfiguration) extends AbstractModule {
   def configure() {
     bind(classOf[JobStats]).in(Scopes.SINGLETON)
   }

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/config/StatsPublisherConfiguration.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/config/StatsPublisherConfiguration.scala
@@ -2,9 +2,6 @@ package org.apache.mesos.chronos.scheduler.config
 
 import org.rogach.scallop.ScallopConf
 
-/**
-  * Created by bthapaliya on 24/11/15.
-  */
 trait StatsPublisherConfiguration extends ScallopConf{
   lazy val webhookUrl = opt[String]("stats_webhook_url",
     descr = "Url to which tasks statistics are pushed",

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/config/StatsPublisherConfiguration.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/config/StatsPublisherConfiguration.scala
@@ -1,0 +1,17 @@
+package org.apache.mesos.chronos.scheduler.config
+
+import org.rogach.scallop.ScallopConf
+
+/**
+  * Created by bthapaliya on 24/11/15.
+  */
+trait StatsPublisherConfiguration extends ScallopConf{
+  lazy val webhookUrl = opt[String]("stats_webhook_url",
+    descr = "Url to which tasks statistics are pushed",
+    default = None)
+
+  lazy val webhookPort = opt[Int]("stats_webhook_port",
+    descr = "Port where the stats are pushed",
+    default = Some(8080))
+
+}

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/stats/JobStats.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/stats/JobStats.scala
@@ -1,7 +1,5 @@
 package org.apache.mesos.chronos.scheduler.jobs.stats
 
-import com.fasterxml.jackson.core.JsonFactory
-
 import scala.collection._
 import java.util.concurrent.ConcurrentHashMap
 import java.util.logging.{Level, Logger}
@@ -11,6 +9,7 @@ import java.net.{HttpURLConnection, URL}
 import com.datastax.driver.core.exceptions.{DriverException, NoHostAvailableException, QueryExecutionException, QueryValidationException}
 import com.datastax.driver.core.querybuilder.{Insert, QueryBuilder}
 import com.datastax.driver.core._
+import com.fasterxml.jackson.core.JsonFactory
 import com.google.inject.Inject
 import org.apache.mesos.Protos.{TaskState, TaskStatus}
 import org.apache.mesos.chronos.scheduler.config.{StatsPublisherConfiguration, CassandraConfiguration}

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/stats/JobStats.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/stats/JobStats.scala
@@ -1,15 +1,19 @@
 package org.apache.mesos.chronos.scheduler.jobs.stats
 
+import com.fasterxml.jackson.core.JsonFactory
+
 import scala.collection._
 import java.util.concurrent.ConcurrentHashMap
 import java.util.logging.{Level, Logger}
+import java.io.{DataOutputStream, StringWriter}
+import java.net.{HttpURLConnection, URL}
 
 import com.datastax.driver.core.exceptions.{DriverException, NoHostAvailableException, QueryExecutionException, QueryValidationException}
 import com.datastax.driver.core.querybuilder.{Insert, QueryBuilder}
 import com.datastax.driver.core._
 import com.google.inject.Inject
 import org.apache.mesos.Protos.{TaskState, TaskStatus}
-import org.apache.mesos.chronos.scheduler.config.CassandraConfiguration
+import org.apache.mesos.chronos.scheduler.config.{StatsPublisherConfiguration, CassandraConfiguration}
 import org.apache.mesos.chronos.scheduler.jobs._
 import org.joda.time.DateTime
 
@@ -20,7 +24,9 @@ object CurrentState extends Enumeration {
   val idle, queued, running = Value
 }
 
-class JobStats @Inject()(clusterBuilder: Option[Cluster.Builder], config: CassandraConfiguration) {
+class JobStats @Inject()(clusterBuilder: Option[Cluster.Builder],
+                         config: CassandraConfiguration with StatsPublisherConfiguration,
+                         jobmetrics: JobMetrics) {
 
   // Cassandra table column names
   private val ATTEMPT: String = "attempt"
@@ -495,6 +501,24 @@ class JobStats @Inject()(clusterBuilder: Option[Cluster.Builder], config: Cassan
       attempt: Option[Integer],
       isFailure: Option[Boolean]) = {
     try {
+      config.webhookUrl.get match{
+        case Some(url) => pushNotificationToHook(
+                            url,
+                            config.webhookPort.get.get,
+                            id,
+                            timestamp,
+                            jobName,
+                            jobOwner,
+                            jobSchedule,
+                            jobParents,
+                            taskState,
+                            slaveId,
+                            message,
+                            attempt,
+                            isFailure)
+        case _ => None
+      }
+
       getSession.foreach {
         session =>
           val query:Insert = QueryBuilder.insertInto(config.cassandraTable())
@@ -562,4 +586,99 @@ class JobStats @Inject()(clusterBuilder: Option[Cluster.Builder], config: Cassan
       ConsistencyLevel.valueOf(config.cassandraConsistency())
     }
   }
+
+  private def pushNotificationToHook(hookurl: String,
+                                     port: Int,
+                                     id: Option[String],
+                                     timestamp: Option[java.util.Date],
+                                     jobName: Option[String],
+                                     jobOwner: Option[String],
+                                     jobSchedule: Option[String],
+                                     jobParents: Option[java.util.Set[String]],
+                                     taskState: Option[String],
+                                     slaveId: Option[String],
+                                     message: Option[String],
+                                     attempt: Option[Integer],
+                                     isFailure: Option[Boolean]) = {
+    val jsonBuffer = new StringWriter
+    val factory = new JsonFactory()
+    val generator = factory.createGenerator(jsonBuffer)
+
+    // Create the payload
+    generator.writeStartObject()
+
+    generator.writeStringField("taskId", id.get);
+    generator.writeStringField("ts", timestamp.get.toString());
+    generator.writeStringField("job_name", jobName.get);
+
+    jobOwner match {
+      case Some(jo: String) => generator.writeStringField("job_owner", jo)
+      case _ =>
+    }
+    jobSchedule match {
+      case Some(js: String) => generator.writeStringField("job_schedule", js)
+      case _ =>
+    }
+    jobParents match {
+      case Some(jp: java.util.Set[String]) => generator.writeStringField("job_parents", jp.toString())
+      case _ =>
+    }
+    taskState match {
+      case Some(ts: String) => generator.writeStringField("task_state", ts)
+      case _ =>
+    }
+    slaveId match {
+      case Some(s: String) => generator.writeStringField("slave_id", s)
+      case _ =>
+    }
+    message match {
+      case Some(m: String) => generator.writeStringField("message", m)
+      case _ =>
+    }
+    attempt match {
+      case Some(a: Integer) => generator.writeStringField("attempt", a.toString())
+      case _ =>
+    }
+    isFailure match {
+      case Some(f: Boolean) => generator.writeStringField("is_failure", f.toString())
+      case _ =>
+    }
+
+    val histstat = jobmetrics.getJsonStats(jobName.get)
+
+    generator.writeFieldName("histogram")
+    generator.writeRawValue(histstat)
+
+    generator.writeEndObject()
+    generator.flush()
+
+    val payload = jsonBuffer.toString
+
+
+    var connection: HttpURLConnection = null
+    try {
+      val url = new URL(hookurl+':'+port)
+      connection = url.openConnection.asInstanceOf[HttpURLConnection]
+      connection.setDoInput(true)
+      connection.setDoOutput(true)
+      connection.setUseCaches(false)
+      connection.setRequestMethod("POST")
+      connection.setRequestProperty("Content-Type","application/json");
+
+      val outputStream = new DataOutputStream(connection.getOutputStream)
+      outputStream.writeBytes(payload)
+      outputStream.flush()
+      outputStream.close()
+
+      log.info("Sent message to http endpoint. Response code:" +
+        connection.getResponseCode +
+        " - " +
+        connection.getResponseMessage)
+    } finally {
+      if (connection != null) {
+        connection.disconnect()
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Currently, the httpNotification only works for notifying failures. To be able to have the same kind of statistics as cassandra has but not in cassandra, we have added a webhook integration as discussed in #564 with @andygrunwald. 
The JobStats is too coupled with Cassndra at the moment. I think seperating cassandra from JobStats is a good idea to be discussed. But this PR basically adds a publisher to push the data similar to Cassandra. Along with that, it also sends metrics in a json format. 
How data is sent:

``` json
{
    "attempt": "0",
    "histogram": {
        "75thPercentile": 14155.0,
        "95thPercentile": 16132.0,
        "98thPercentile": 16132.0,
        "99thPercentile": 16132.0,
        "count": 13,
        "mean": 13168.0,
        "median": 13168.0
    },
    "job_name": "RecurringSleep",
    "job_owner": "bidesh.thapaliya@trivago.com",
    "job_schedule": "R/2015-11-26T13:57:44.000Z/PT20S",
    "slave_id": "caa576d0-a3c8-494c-aad0-d2101ce6bc33-S1",
    "taskId": "ct:1448546204000:0:RecurringSleep:",
    "task_state": "TASK_RUNNING",
    "ts": "Thu Nov 26 13:56:44 UTC 2015"
}
```

This is the first approach. We would be very happy to get your feedback on this PR on your general interest in getting this feature into chronos. 
