### PR TITLE
Fixing initial copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -185,12 +185,12 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright 2015 Airbnb
-Copyright 2015 Mesosphere
+Copyright 2013-2016 Airbnb
+Copyright 2013-2016 Mesosphere
 
 This file has been modified from its original form by Mesosphere, 
 Inc. (“Mesosphere”). All modifications made to this file by 
-Mesosphere (the “Modifications”) are © 2015 Mesosphere. The 
+Mesosphere (the “Modifications”) are © 2013-2016 Mesosphere. The 
 Modifications are licensed to you under the Apache License, Version 
 2.0.
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,7 @@
-Copyright 2015 Airbnb
-Copyright 2015 Mesosphere
+Copyright 2013-2016 Airbnb
+Copyright 2013-2016 Mesosphere
 
-This file has been modified from its original form by Mesosphere, Inc. (“Mesosphere”). All modifications made to this file by Mesosphere (the “Modifications”) are © 2015 Mesosphere. The Modifications are licensed to you under the Apache License, Version 2.0.
+This file has been modified from its original form by Mesosphere, Inc. (“Mesosphere”). All modifications made to this file by Mesosphere (the “Modifications”) are © 2013-2016 Mesosphere. The Modifications are licensed to you under the Apache License, Version 2.0.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 


### PR DESCRIPTION
According to http://www.copyright.gov/circs/circ01.pdf , document should list its first year of publication in its copyright