### PR TITLE
keep properties when a dependency job change to a schedule based job

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
@@ -93,7 +93,17 @@ class JobManagementResource @Inject()(val jobScheduler: JobScheduler,
                       softError = childJob.softError,
                       uris = childJob.uris,
                       fetch = childJob.fetch,
-                      highPriority = childJob.highPriority
+                      highPriority = childJob.highPriority,
+                      ownerName = childJob.ownerName,
+                      description = childJob.description,
+                      errorsSinceLastSuccess = childJob.errorsSinceLastSuccess,
+                      runAsUser = childJob.runAsUser,
+                      container = childJob.container,
+                      environmentVariables = childJob.environmentVariables,
+                      shell = childJob.shell,
+                      arguments = childJob.arguments,
+                      dataProcessingJobType = childJob.dataProcessingJobType,
+                      constraints = childJob.constraints
                     )
                     jobScheduler.updateJob(childJob, newChild)
                   case _ =>


### PR DESCRIPTION
If job A is a schedule based job, job B is a dependency job. When A is removed from job list, job B will change to a schedule based job automatically. The code about this is use the construct function of schedule based job, pass each property of B. But it forget some property. Some of them are not very important, like description. Some of them are important, like constraint. I added all the property of base job.

Change-Id: Ide1d07eea04213969849a962bd8a96bc5be06897
