### PR TITLE
add an api endpoint for getting the current leader

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/ChronosRestModule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/ChronosRestModule.scala
@@ -52,6 +52,7 @@ class ChronosRestModule extends ServletModule {
     bind(classOf[MetricsServlet]).in(Scopes.SINGLETON)
     bind(classOf[LogConfigServlet]).in(Scopes.SINGLETON)
     bind(classOf[ConstraintViolationExceptionMapper]).in(Scopes.SINGLETON)
+    bind(classOf[LeaderResource]).in(Scopes.SINGLETON)
 
     serve(pingUrl).`with`(classOf[PingServlet])
     serve(metricsUrl).`with`(classOf[MetricsServlet])

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/LeaderRestModule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/LeaderRestModule.scala
@@ -1,0 +1,18 @@
+package org.apache.mesos.chronos.scheduler.api
+
+import org.apache.mesos.chronos.scheduler.jobs.JobScheduler
+import javax.ws.rs.core.{MediaType, Response}
+import javax.ws.rs.{GET, Path, Produces}
+import com.google.inject.Inject
+
+
+@Path(PathConstants.getLeaderPattern)
+@Produces(Array(MediaType.APPLICATION_JSON))
+class LeaderResource @Inject()(
+  val jobScheduler: JobScheduler
+) {
+  @GET
+  def getLeader(): Response = {
+    Response.ok(Map("leader" -> jobScheduler.getLeader)).build
+  }
+}

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/PathConstants.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/PathConstants.scala
@@ -20,6 +20,7 @@ object PathConstants {
   final val jobGraphDotPath = "dot"
   final val jobGraphCsvPath = "csv"
   final val killTaskPattern = "kill/{jobName}"
+  final val getLeaderPattern = "/leader"
 
   final val isMasterPath = "isMaster"
   final val taskBasePath = "/task"


### PR DESCRIPTION
This adds a /scheduler/leader endpoint for getting the current leader.
It returns JSON in the structure of {'leader': leader}.
