### PR TITLE
Dedup ScheduleStream by jobName.

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
@@ -722,7 +722,13 @@ class JobScheduler @Inject()(val scheduleHorizon: Period,
     log.info("Adding schedule for time:" + now.toString(DateTimeFormat.fullTime()))
     lock.synchronized {
       log.fine("Starting iteration")
-      streams = iteration(now, newStreams ++ streams)
+      for(stream <- newStreams) {
+        if (!streams.exists(_.jobName == stream.jobName)) {
+          streams = streams :+ stream
+        }
+      }
+
+      streams = iteration(now, streams)
       log.fine("Size of streams: %d".format(streams.size))
     }
   }


### PR DESCRIPTION
chronos with only one server instance will be switched to `Defeated` status if it's disconnected to zookeeper and be switched to `Elected` if it's connected to zookeeper. In this case, chronos load job from zookeeper and add ScheduleStream into streams in JobScheduler. If we don't dedup ScheduleStream by jobName, the size of streams will increase unexpetedly as follows:

```
[INFO] [pool-5-thread-1] 06-10 00:01:00,468 [JobScheduler] - Size of streams: 150
......
[INFO] [pool-5-thread-1] 06-10 19:01:46,113 [JobScheduler] - Defeated. Not the current leader.
[INFO] [main-EventThread] 06-10 19:01:59,900 [ConnectionStateManager] - State change: RECONNECTED
[INFO] [pool-5-thread-1] 06-10 19:01:59,905 [JobScheduler] - Elected as leader.
....
[INFO] [pool-5-thread-1] 06-10 19:02:35,965 [JobScheduler] - Size of streams: 231
```

Obviously, there are many ScheduleStreams which are duplicated in streams. If some jobs' tasks fail, chronos' JobScheduler may run into unexpected status like `dead lock`.