### PR TITLE
Re-enable job arguments feature

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
@@ -150,8 +150,8 @@ class JobManagementResource @Inject()(val jobScheduler: JobScheduler,
     try {
       require(jobGraph.lookupVertex(jobName).isDefined, "Job '%s' not found".format(jobName))
       val job = jobGraph.getJobForName(jobName).get
-      log.info("Manually triggering job:" + jobName)
-      jobScheduler.taskManager.enqueue(TaskUtils.getTaskId(job, DateTime.now(DateTimeZone.UTC), 0), job.highPriority)
+      log.info("Manually triggering job: " + jobName + ", arguments: " + arguments)
+      jobScheduler.taskManager.enqueue(TaskUtils.getTaskId(job, DateTime.now(DateTimeZone.UTC), 0, arguments), job.highPriority)
       Response.noContent().build
     } catch {
       case ex: IllegalArgumentException =>

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtils.scala
@@ -99,8 +99,12 @@ object TaskUtils {
     })
   }
 
-  def getTaskId(job: BaseJob, due: DateTime, attempt: Int = 0): String = {
-    taskIdTemplate.format(due.getMillis, attempt, job.name, job.arguments.mkString(" "))
+  def getTaskId(job: BaseJob, due: DateTime, attempt: Int = 0, arguments: String = ""): String = {
+    if (arguments != null && !arguments.isEmpty()) {
+      taskIdTemplate.format(due.getMillis, attempt, job.name, arguments)
+    } else {
+      taskIdTemplate.format(due.getMillis, attempt, job.name, job.arguments.mkString(" "))
+    }
   }
 
   def getDueTimes(tasks: Map[String, Array[Byte]]): Map[String, (BaseJob, Long, Int)] = {

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtilsSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtilsSpec.scala
@@ -9,14 +9,13 @@ class TaskUtilsSpec extends SpecificationWithJUnit with Mockito {
   "TaskUtils" should {
     "Get taskId" in {
       val schedule = "R/2012-01-01T00:00:01.000Z/P1M"
-      val arguments = "-a 1 -b 2"
-      val job1 = new ScheduleBasedJob(schedule, "sample-name", "sample-command", arguments = List(arguments))
-      val job2 = new ScheduleBasedJob(schedule, "sample-name", "sample-command")
+      val job = new ScheduleBasedJob(schedule, "sample-name", "sample-command")
       val ts = 1420843781398L
       val due = new DateTime(ts)
+      val arguments = "-a 1 -b 2"
 
-      val taskIdOne = TaskUtils.getTaskId(job1, due, 0)
-      val taskIdTwo = TaskUtils.getTaskId(job2, due, 0)
+      val taskIdOne = TaskUtils.getTaskId(job, due, 0, arguments)
+      val taskIdTwo = TaskUtils.getTaskId(job, due, 0)
 
       taskIdOne must_== "ct:1420843781398:0:sample-name:" + arguments
       taskIdTwo must_== "ct:1420843781398:0:sample-name:"


### PR DESCRIPTION
With commit 1a7868e1b7cdc87d4cae29d15e572b66b7ae20c3 job arguments were broken/completely removed (I guess not intentionally since it's still in the [docs](https://mesos.github.io/chronos/docs/api.html#manually-starting-a-job)). This PR is adding the feature again also making sure that null or empty arguments are handled properly (fallback to job default args).
