### PR TITLE
Change default framework name

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -97,7 +97,7 @@ If you installed chronos via package, run `/usr/bin/chronos run_jar --help`.
       --mesos_authentication_secret_file  <arg>   Mesos Authentication Secret
       --mesos_checkpoint                          Enable checkpointing in Mesos
       --mesos_framework_name  <arg>               The framework name
-                                                  (default = chronos-2.3.5-SNAPSHOT)
+                                                  (default = chronos)
       --mesos_role  <arg>                         The Mesos role to run tasks
                                                   under (default = *)
       --mesos_task_cpu  <arg>                     Number of CPUs to request from

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/config/SchedulerConfiguration.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/config/SchedulerConfiguration.scala
@@ -107,7 +107,7 @@ trait SchedulerConfiguration extends ScallopConf {
     Option(classOf[SchedulerConfiguration].getPackage.getImplementationVersion).getOrElse("unknown")
   lazy val mesosFrameworkName = opt[String]("mesos_framework_name",
     descr = "The framework name",
-    default = Some("chronos-" + version))
+    default = Some("chronos"))
   lazy val webuiUrl = opt[String]("webui_url",
     descr = "The http(s) url of the web ui, defaulting to the advertised hostname",
     noshort = true,


### PR DESCRIPTION
This removes the version from the default framework name. This brings Chronos inline with other frameworks that don't include the version number in this field.

I hope there's no reason why Chronos currently includes the version number, please let me know if that's the case!
