### PR TITLE
Potential fix for mesos/chronos#553

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtils.scala
@@ -18,10 +18,10 @@ import scala.collection.mutable
 
 object TaskUtils {
 
-  //TaskIdFormat: ct:JOB_NAME:DUE:ATTEMPT:ARGUMENTS
-  val taskIdTemplate = "ct:%d:%d:%s:%s"
+  //TaskIdFormat: ct~JOB_NAME~DUE~ATTEMPT~ARGUMENTS
+  val taskIdTemplate = "ct~%d~%d~%s~%s"
   val argumentsPattern = """(.*)?""".r
-  val taskIdPattern = """ct:(\d+):(\d+):%s:?%s""".format(JobUtils.jobNamePattern, argumentsPattern).r
+  val taskIdPattern = """ct~(\d+)~(\d+)~%s~?%s""".format(JobUtils.jobNamePattern, argumentsPattern).r
   val commandInjectionFilter = ";".toSet
 
   private[this] val log = Logger.getLogger(getClass.getName)

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManagerSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManagerSpec.scala
@@ -34,13 +34,13 @@ class TaskManagerSpec extends SpecificationWithJUnit with Mockito {
       val job = new ScheduleBasedJob("R/2012-01-01T00:00:01.000Z/PT1M", "test", "sample-command")
 
       mockJobGraph.lookupVertex("test").returns(Some(job)) // so we can enqueue a job.
-      taskManager.enqueue("ct:1420843781398:0:test:", highPriority = true)
+      taskManager.enqueue("ct~1420843781398~0~test~", highPriority = true)
 
       mockJobGraph.getJobForName("test").returns(None)
 
       taskManager.getTask must_== None
 
-      there was one(mockPersistencStore).removeTask("ct:1420843781398:0:test:")
+      there was one(mockPersistencStore).removeTask("ct~1420843781398~0~test~")
     }
 
     "Revive offers when adding a new task and --revive_offers_for_new_jobs is set" in {
@@ -55,7 +55,7 @@ class TaskManagerSpec extends SpecificationWithJUnit with Mockito {
       val job = new ScheduleBasedJob("R/2012-01-01T00:00:01.000Z/PT1M", "test", "sample-command")
       mockJobGraph.lookupVertex("test").returns(Some(job)) // so we can enqueue a job.
 
-      taskManager.enqueue("ct:1420843781398:0:test:", highPriority = true)
+      taskManager.enqueue("ct~1420843781398~0~test~", highPriority = true)
 
       there was one(mockMesosOfferReviver).reviveOffers
     }
@@ -72,7 +72,7 @@ class TaskManagerSpec extends SpecificationWithJUnit with Mockito {
       val job = new ScheduleBasedJob("R/2012-01-01T00:00:01.000Z/PT1M", "test", "sample-command")
       mockJobGraph.lookupVertex("test").returns(Some(job)) // so we can enqueue a job.
 
-      taskManager.enqueue("ct:1420843781398:0:test:", highPriority = true)
+      taskManager.enqueue("ct~1420843781398~0~test~", highPriority = true)
 
       there were noCallsTo(mockMesosOfferReviver)
     }

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtilsSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/TaskUtilsSpec.scala
@@ -22,15 +22,15 @@ class TaskUtilsSpec extends SpecificationWithJUnit with Mockito {
       val taskIdThree = TaskUtils.getTaskId(job3, due, 0, Option(cmdArgs))
       val taskIdFour = TaskUtils.getTaskId(job2, due, 0, Option(cmdArgs))
 
-      taskIdOne must_== "ct:1420843781398:0:sample-name:" + arguments
-      taskIdTwo must_== "ct:1420843781398:0:sample-name:"
-      taskIdThree must_== "ct:1420843781398:0:sample-name:" + cmdArgs    // test override
-      taskIdFour must_== "ct:1420843781398:0:sample-name:" + cmdArgs    // test adding args
+      taskIdOne must_== "ct~1420843781398~0~sample-name~" + arguments
+      taskIdTwo must_== "ct~1420843781398~0~sample-name~"
+      taskIdThree must_== "ct~1420843781398~0~sample-name~" + cmdArgs    // test override
+      taskIdFour must_== "ct~1420843781398~0~sample-name~" + cmdArgs    // test adding args
     }
 
     "Get job arguments for taskId" in {
       val arguments = "-a 1 -b 2"
-      var taskId = "ct:1420843781398:0:test:" + arguments
+      var taskId = "ct~1420843781398~0~test~" + arguments
       val jobArguments = TaskUtils.getJobArgumentsForTaskId(taskId)
 
       jobArguments must_== arguments
@@ -46,14 +46,14 @@ class TaskUtilsSpec extends SpecificationWithJUnit with Mockito {
 
       val taskIdOne = TaskUtils.getTaskId(job1, due, 0, Option(cmdArgs))
 
-      taskIdOne must_== "ct:1420843781398:0:sample-name:" + expectedArgs
+      taskIdOne must_== "ct~1420843781398~0~sample-name~" + expectedArgs
     }
 
     "Parse taskId" in {
       val arguments = "-a 1 -b 2"
       val arguments2 = "-a 1:2 --B test"
 
-      val taskIdOne = "ct:1420843781398:0:test:" + arguments
+      val taskIdOne = "ct~1420843781398~0~test~" + arguments
       val (jobName, jobDue, attempt, jobArguments) = TaskUtils.parseTaskId(taskIdOne)
 
       jobName must_== "test"
@@ -61,12 +61,12 @@ class TaskUtilsSpec extends SpecificationWithJUnit with Mockito {
       attempt must_== 0
       jobArguments must_== arguments
 
-      val taskIdTwo = "ct:1420843781398:0:test:" + arguments2
+      val taskIdTwo = "ct~1420843781398~0~test~" + arguments2
       val (_, _, _, jobArguments2) = TaskUtils.parseTaskId(taskIdTwo)
 
       jobArguments2 must_== arguments2
 
-      val taskIdThree = "ct:1420843781398:0:test"
+      val taskIdThree = "ct~1420843781398~0~test"
       val (jobName3, _, _, jobArguments3) = TaskUtils.parseTaskId(taskIdThree)
 
       jobName3 must_== "test"

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/mesos/MesosTaskBuilderSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/mesos/MesosTaskBuilderSpec.scala
@@ -14,7 +14,7 @@ import org.specs2.mutable.SpecificationWithJUnit
 
 class MesosTaskBuilderSpec extends SpecificationWithJUnit with Mockito {
 
-  val taskId = "ct:1454467003926:0:test2Execution:run"
+  val taskId = "ct~1454467003926~0~test2Execution~run"
 
   val (_, start, attempt, _) = TaskUtils.parseTaskId(taskId)
 


### PR DESCRIPTION
This patch fixes #553 by replacing ":" with "~" in the path. This addresses faulty behavior when using a chronos executor path in a variable like `$PATH`, `$PYTHONPATH`, `$CLASSPATH`, etc. which typically uses a ":" to separate paths.