### PR TITLE
support for user networks when using docker-containers

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Containers.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/Containers.scala
@@ -9,14 +9,7 @@ object VolumeMode extends Enumeration {
   val RW, RO = Value
 }
 
-object NetworkMode extends Enumeration {
-  type NetworkMode = Value
 
-  // Bridged and Host
-  val BRIDGE, HOST = Value
-}
-
-import org.apache.mesos.chronos.scheduler.jobs.NetworkMode._
 import org.apache.mesos.chronos.scheduler.jobs.VolumeMode._
 
 case class Volume(
@@ -28,5 +21,5 @@ case class DockerContainer(
                             @JsonProperty image: String,
                             @JsonProperty volumes: Seq[Volume],
                             @JsonProperty parameters: Seq[Parameter],
-                            @JsonProperty network: NetworkMode = NetworkMode.HOST,
+                            @JsonProperty network: String = "HOST",
                             @JsonProperty forcePullImage: Boolean = false)

--- a/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
+++ b/src/main/scala/org/apache/mesos/chronos/utils/JobDeserializer.scala
@@ -165,8 +165,8 @@ class JobDeserializer extends JsonDeserializer[BaseJob] {
       val containerNode = node.get("container")
       val networkMode =
         if (containerNode.has("network") && containerNode.get("network") != null)
-          NetworkMode.withName(containerNode.get("network").asText)
-        else NetworkMode.HOST
+          containerNode.get("network").asText
+        else "HOST"
 
       // TODO: Add support for more containers when they're added.
       val volumes = scala.collection.mutable.ListBuffer[Volume]()

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/api/SerDeTest.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/api/SerDeTest.scala
@@ -32,7 +32,7 @@ class SerDeTest extends SpecificationWithJUnit {
 
       var parameters = scala.collection.mutable.ListBuffer[Parameter]()
 
-      val container = DockerContainer("dockerImage", volumes, parameters, NetworkMode.BRIDGE, forcePullImage)
+      val container = DockerContainer("dockerImage", volumes, parameters, "BRIDGE", forcePullImage)
 
       val arguments = Seq(
         "-testOne"
@@ -78,7 +78,7 @@ class SerDeTest extends SpecificationWithJUnit {
       val forcePullImage = true
       var parameters = scala.collection.mutable.ListBuffer[Parameter]()
 
-      val container = DockerContainer("dockerImage", volumes, parameters, NetworkMode.HOST, forcePullImage)
+      val container = DockerContainer("dockerImage", volumes, parameters, "HOST", forcePullImage)
 
       val arguments = Seq(
         "-testOne"

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/mesos/MesosTaskBuilderSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/mesos/MesosTaskBuilderSpec.scala
@@ -33,7 +33,7 @@ class MesosTaskBuilderSpec extends SpecificationWithJUnit with Mockito {
 
     var parameters = scala.collection.mutable.ListBuffer[Parameter]()
 
-    val container = DockerContainer("dockerImage", volumes, parameters, NetworkMode.HOST, true)
+    val container = DockerContainer("dockerImage", volumes, parameters, "HOST", true)
 
     val constraints = Seq(
       EqualsConstraint("rack", "rack-1"),
@@ -92,8 +92,58 @@ class MesosTaskBuilderSpec extends SpecificationWithJUnit with Mockito {
         EnvironmentVariable("CHRONOS_RESOURCE_MEM", "10000"),
         EnvironmentVariable("CHRONOS_RESOURCE_DISK", "40000")
       ))
-      
+
       defaultEnv must_== toMap(target.envs(taskId, testJob, offer).build())
+    }
+  }
+
+  "MesosTaskBuilder" should {
+    "create simple container info with HOST networking" in {
+      val target = new MesosTaskBuilder(mock[SchedulerConfiguration])
+      val schedule = "R/2012-01-01T00:00:01.000Z/PT1M"
+      val containerInfo = target.createContainerInfo(ScheduleBasedJob(schedule, "sample-name", "sample-command",
+        container = DockerContainer("image1", Seq(), Seq(), "host", forcePullImage = false)))
+      containerInfo.toString must_==
+        """|type: DOCKER
+          |docker {
+          |  image: "image1"
+          |  network: HOST
+          |  force_pull_image: false
+          |}
+          |""".stripMargin
+    }
+
+    "create simple container info with BRIDGE networking" in {
+      val target = new MesosTaskBuilder(mock[SchedulerConfiguration])
+      val schedule = "R/2012-01-01T00:00:01.000Z/PT1M"
+      val containerInfo = target.createContainerInfo(ScheduleBasedJob(schedule, "sample-name", "sample-command",
+        container = DockerContainer("image1", Seq(), Seq(), "bridge", forcePullImage = false)))
+      containerInfo.toString must_==
+        """|type: DOCKER
+          |docker {
+          |  image: "image1"
+          |  network: BRIDGE
+          |  force_pull_image: false
+          |}
+          |""".stripMargin
+    }
+
+    "create container info with custom network" in {
+      val target = new MesosTaskBuilder(mock[SchedulerConfiguration])
+      val schedule = "R/2012-01-01T00:00:01.000Z/PT1M"
+      val containerInfo = target.createContainerInfo(ScheduleBasedJob(schedule, "sample-name", "sample-command",
+        container = DockerContainer("image1", Seq(), Seq(), "custom:user:network_1", forcePullImage = false)))
+      containerInfo.toString must_==
+        """|type: DOCKER
+          |docker {
+          |  image: "image1"
+          |  network: USER
+          |  force_pull_image: false
+          |}
+          |network_infos {
+          |  name: "custom:user:network_1"
+          |}
+          |""".stripMargin
     }
   }
 }


### PR DESCRIPTION
Hey,

when playing around with a docker-compose setup in which I am starting a mesos-cluster and a chronos instance, I saw, that chronos does not yet support custom user-networks as described in [http://mesos.apache.org/documentation/latest/networking/](url):

> For NONE, HOST and BRIDGE network mode the framework only needs to specify the network mode in the DockerInfo protobuf. However, for the USER mode, since a user-defined docker network is identified by a canonical network name (similar to CNI networks) apart from setting the network mode in DockerInfo the framework also needs to specify the name field in the NetworkInfo protobuf corresponding to the name of the user-defined docker network.

This pull-request would add the capability to specify USER-networks in the JSON which describes the job.
If you have a custom docker network running (e.g. created by docker-compose) you can connect to it by specifying this:

```json
{
  "container": {
    "type": "DOCKER",
    "image": "your-image",
    "network": "custom-network"
  }
}
``` 
which would create the following ContainerInfo in the MesosTaskBuilder:

```
type: DOCKER
docker {
  image: "your-image"
  network: USER
}
network_infos {
  name: "custom-network"
}
```

Let me know what you think.

Cheers,

Kai