### PR TITLE
Job name validation fix

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
@@ -19,7 +19,7 @@ import scala.collection.mutable.ListBuffer
   */
 object JobUtils {
 
-  val jobNamePattern = """([\w\.-]+)""".r
+  val jobNamePattern = """([\w\s\.#_-]+)""".r
   val stats = new mutable.HashMap[String, DescriptiveStatistics]()
   val maxValues = 100
   //The object mapper, which is, according to the docs, Threadsafe once configured.

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtilsSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtilsSpec.scala
@@ -91,8 +91,31 @@ class JobUtilsSpec extends SpecificationWithJUnit with Mockito {
   }
 
   "Accepts a job name with periods" in {
-    val jobName = "sample.name"
-
-    JobUtils.isValidJobName(jobName)
+    JobUtils.isValidJobName("sample.name")
   }
+
+  "Accepts a job name with " in {
+    JobUtils.isValidJobName("sample.name")
+  }
+
+  "Accepts a job name with dashes" in {
+    JobUtils.isValidJobName("sample-name")
+  }
+
+  "Accepts a job name with underscores" in {
+    JobUtils.isValidJobName("sample_name")
+  }
+
+  "Accepts a job name with number signs" in {
+    JobUtils.isValidJobName("sample#name")
+  }
+
+  "Accepts a job name with whitespaces" in {
+    JobUtils.isValidJobName("sample name")
+  }
+
+  "Not accepts a job name with spec characters" in {
+    JobUtils.isValidJobName("sample@$&name") must_=== false
+  }
+
 }


### PR DESCRIPTION
Documentation declares that job name must `Must match the following regular expression: ([\w\s\.#_-]+)` but in fact Choronos backend uses other regexp.