### PR TITLE
Properly handle `None` type.

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
@@ -10,7 +10,10 @@ import com.google.common.base.Joiner
 import com.google.common.util.concurrent.AbstractIdleService
 import com.google.inject.Inject
 import org.apache.curator.framework.CuratorFramework
-import org.apache.curator.framework.recipes.leader.{LeaderLatch, LeaderLatchListener}
+import org.apache.curator.framework.recipes.leader.{
+  LeaderLatch,
+  LeaderLatchListener
+}
 import org.apache.mesos.Protos.TaskStatus
 import org.apache.mesos.chronos.scheduler.graph.JobGraph
 import org.apache.mesos.chronos.scheduler.mesos.MesosDriverFactory
@@ -41,7 +44,7 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
                              val jobMetrics: JobMetrics,
                              val actorSystem: ActorSystem = ActorSystem())
 //Allows us to let Chaos manage the lifecycle of this class.
-  extends AbstractIdleService {
+    extends AbstractIdleService {
 
   val localExecutor = Executors.newFixedThreadPool(1)
   val schedulerThreadFuture = new AtomicReference[Future[_]]
@@ -51,7 +54,6 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
 
   val supervisor = actorSystem.actorOf(Props[Supervisor], "supervisor")
   val akkaScheduler = actorSystem.scheduler
-
 
   //TODO(FL): Take some methods out of this class.
   val running = new AtomicBoolean(false)
@@ -100,11 +102,13 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
   }
 
   def deregisterJob(job: BaseJob) {
-    require(isLeader, "Cannot deregister a job with this scheduler, not the leader!")
+    require(isLeader,
+            "Cannot deregister a job with this scheduler, not the leader!")
     lock.synchronized {
       log.info("Removing vertex")
 
-      jobGraph.getChildren(job.name)
+      jobGraph
+        .getChildren(job.name)
         .map(x => jobGraph.lookupVertex(x).get)
         .filter {
           case j: DependencyBasedJob => true
@@ -112,11 +116,11 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
         }
         .map(x => x.asInstanceOf[DependencyBasedJob])
         .filter(x => x.parents.size > 1)
-        .foreach({
-          childJob =>
-            log.info("Updating job %s".format(job.name))
-            val copy = childJob.copy(parents = childJob.parents.filter(_ != job.name))
-            updateJob(childJob, copy)
+        .foreach({ childJob =>
+          log.info("Updating job %s".format(job.name))
+          val copy =
+            childJob.copy(parents = childJob.parents.filter(_ != job.name))
+          updateJob(childJob, copy)
         })
 
       jobGraph.removeVertex(job)
@@ -138,7 +142,8 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
     */
   def updateJob(oldJob: BaseJob, newJob: BaseJob) {
     //TODO(FL): Ensure we're using job-ids rather than relying on jobs names for identification.
-    assert(newJob.name == oldJob.name, "Renaming jobs is currently not supported!")
+    assert(newJob.name == oldJob.name,
+           "Renaming jobs is currently not supported!")
 
     replaceJob(oldJob, newJob)
   }
@@ -169,7 +174,11 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
     } else {
       val job = jobOption.get
       val (_, _, attempt, _) = TaskUtils.parseTaskId(taskId)
-      jobsObserver.apply(JobStarted(job, taskStatus, attempt, taskManager.getRunningTaskCount(jobName)))
+      jobsObserver.apply(
+        JobStarted(job,
+                   taskStatus,
+                   attempt,
+                   taskManager.getRunningTaskCount(jobName)))
 
       job match {
         case j: DependencyBasedJob =>
@@ -183,14 +192,19 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
     val newJob = job match {
       case job: ScheduleBasedJob =>
         val now = DateTime.now(DateTimeZone.UTC)
-        val nextJobSchedule = JobUtils.skipForward(job, now).get
-        job.copy(
-          schedule = nextJobSchedule.schedule
-        )
+        JobUtils.skipForward(job, now) match {
+          case Some(newSchedule) =>
+            job.copy(
+              schedule = newSchedule.schedule
+            )
+          case _ =>
+            job.copy()
+        }
       case job: DependencyBasedJob =>
         job.copy()
       case _ =>
-        throw new scala.IllegalArgumentException("Cannot handle unknown task type")
+        throw new scala.IllegalArgumentException(
+          "Cannot handle unknown task type")
     }
     newJob
   }
@@ -199,7 +213,8 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
     * Takes care of follow-up actions for a finished task, i.e. update the job schedule in the persistence store or
     * launch tasks for dependent jobs
     */
-  def handleFinishedTask(taskStatus: TaskStatus, taskDate: Option[DateTime] = None) {
+  def handleFinishedTask(taskStatus: TaskStatus,
+                         taskDate: Option[DateTime] = None) {
     // `taskDate` is purely for unit testing
     val taskId = taskStatus.getTaskId.getValue
     if (!TaskUtils.isValidVersion(taskId)) {
@@ -214,10 +229,16 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
       log.warning("JobSchedule '%s' no longer registered.".format(jobName))
     } else {
       val (_, start, attempt, _) = TaskUtils.parseTaskId(taskId)
-      jobMetrics.updateJobStat(jobName, timeMs = DateTime.now(DateTimeZone.UTC).getMillis - start)
+      jobMetrics.updateJobStat(
+        jobName,
+        timeMs = DateTime.now(DateTimeZone.UTC).getMillis - start)
       jobMetrics.updateJobStatus(jobName, success = true)
       val job = jobOption.get
-      jobsObserver.apply(JobFinished(job, taskStatus, attempt, taskManager.getRunningTaskCount(job.name)))
+      jobsObserver.apply(
+        JobFinished(job,
+                    taskStatus,
+                    attempt,
+                    taskManager.getRunningTaskCount(job.name)))
 
       val newJob = getNewSuccessfulJob(job)
       replaceJob(job, newJob)
@@ -232,17 +253,23 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
         in between */
       job match {
         case job: ScheduleBasedJob =>
-          val scheduleBasedJob: ScheduleBasedJob = newJob.asInstanceOf[ScheduleBasedJob]
-          Iso8601Expressions.parse(scheduleBasedJob.schedule, scheduleBasedJob.scheduleTimeZone) match {
+          val scheduleBasedJob: ScheduleBasedJob =
+            newJob.asInstanceOf[ScheduleBasedJob]
+          Iso8601Expressions.parse(scheduleBasedJob.schedule,
+                                   scheduleBasedJob.scheduleTimeZone) match {
             case Some((recurrences, _, _)) =>
               if (recurrences == 0) {
                 log.info("Disabling job that reached a zero-recurrence count!")
 
-                val disabledJob: ScheduleBasedJob = scheduleBasedJob.copy(disabled = true)
-                jobsObserver.apply(JobDisabled(job,
-                  """JobSchedule '%s' has exhausted all of its recurrences and has been disabled.
+                val disabledJob: ScheduleBasedJob =
+                  scheduleBasedJob.copy(disabled = true)
+                jobsObserver.apply(
+                  JobDisabled(
+                    job,
+                    """JobSchedule '%s' has exhausted all of its recurrences and has been disabled.
                     |Please consider either removing your job, or updating its schedule and re-enabling it.
-                  """.stripMargin.format(job.name)))
+                  """.stripMargin.format(job.name)
+                  ))
                 replaceJob(scheduleBasedJob, disabledJob)
               }
             case None =>
@@ -257,23 +284,25 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
       case job: ScheduleBasedJob =>
         val now = DateTime.now(DateTimeZone.UTC)
         job.copy(successCount = job.successCount + 1,
-          errorsSinceLastSuccess = 0,
-          lastSuccess = now.toString
-        )
+                 errorsSinceLastSuccess = 0,
+                 lastSuccess = now.toString)
       case job: DependencyBasedJob =>
         job.copy(successCount = job.successCount + 1,
-          errorsSinceLastSuccess = 0,
-          lastSuccess = DateTime.now(DateTimeZone.UTC).toString)
+                 errorsSinceLastSuccess = 0,
+                 lastSuccess = DateTime.now(DateTimeZone.UTC).toString)
       case _ =>
-        throw new scala.IllegalArgumentException("Cannot handle unknown task type")
+        throw new scala.IllegalArgumentException(
+          "Cannot handle unknown task type")
     }
     newJob
   }
 
-  private def processDependencies(jobName: String, taskDate: Option[DateTime]) {
+  private def processDependencies(jobName: String,
+                                  taskDate: Option[DateTime]) {
     val dependents = jobGraph.getExecutableChildren(jobName)
     if (dependents.nonEmpty) {
-      log.fine("%s has dependents: %s .".format(jobName, dependents.mkString(",")))
+      log.fine(
+        "%s has dependents: %s .".format(jobName, dependents.mkString(",")))
       dependents.foreach {
         //TODO(FL): Ensure that the job for the given x exists. Lock.
         x =>
@@ -283,8 +312,8 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
               case Some(d) => d
               case None => DateTime.now(DateTimeZone.UTC)
             }
-            taskManager.enqueue(TaskUtils.getTaskId(dependentJob,
-              date), dependentJob.highPriority)
+            taskManager.enqueue(TaskUtils.getTaskId(dependentJob, date),
+                                dependentJob.highPriority)
 
             log.fine("Enqueued depedent job." + x)
           }
@@ -300,7 +329,8 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
   def markJobSuccessAndFireOffDependencies(jobName: String): Boolean = {
     val optionalJob = jobGraph.getJobForName(jobName)
     if (optionalJob.isEmpty) {
-      log.warning("%s not found in job graph, not marking success".format(jobName))
+      log.warning(
+        "%s not found in job graph, not marking success".format(jobName))
       return false
     } else {
       val job = optionalJob.get
@@ -325,12 +355,18 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
       val jobOption = jobGraph.lookupVertex(jobName)
       jobOption match {
         case Some(job) =>
-          jobsObserver.apply(JobFailed(Right(job), taskStatus, attempt, taskManager.getRunningTaskCount(job.name)))
+          jobsObserver.apply(
+            JobFailed(Right(job),
+                      taskStatus,
+                      attempt,
+                      taskManager.getRunningTaskCount(job.name)))
 
           val hasAttemptsLeft: Boolean = attempt < job.retries
           val hadRecentSuccess: Boolean = try {
             job.lastError.length > 0 && job.lastSuccess.length > 0 &&
-              (DateTime.parse(job.lastSuccess).getMillis - DateTime.parse(job.lastError).getMillis) >= 0
+            (DateTime.parse(job.lastSuccess).getMillis - DateTime
+              .parse(job.lastError)
+              .getMillis) >= 0
           } catch {
             case ex: IllegalArgumentException =>
               log.warning(s"Couldn't parse last run date from ${job.name}")
@@ -339,11 +375,15 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
           }
 
           if (hasAttemptsLeft && (job.lastError.length == 0 || hadRecentSuccess)) {
-            log.warning("Retrying job: %s, attempt: %d".format(jobName, attempt))
+            log.warning(
+              "Retrying job: %s, attempt: %d".format(jobName, attempt))
             /* Schedule the retry up to 60 seconds in the future */
             val delayDuration = new Duration(failureRetryDelay)
-            val newTaskId = TaskUtils.getTaskId(job, DateTime.now(DateTimeZone.UTC)
-              .plus(delayDuration), attempt + 1)
+            val newTaskId = TaskUtils.getTaskId(job,
+                                                DateTime
+                                                  .now(DateTimeZone.UTC)
+                                                  .plus(delayDuration),
+                                                attempt + 1)
             val delayedTask = new Runnable {
               def run() {
                 log.info(s"Enqueuing failed task $newTaskId")
@@ -353,7 +393,8 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
             implicit val executor = actorSystem.dispatcher
 
             akkaScheduler.scheduleOnce(
-              delay = scala.concurrent.duration.Duration(delayDuration.getMillis, TimeUnit.MILLISECONDS),
+              delay = scala.concurrent.duration
+                .Duration(delayDuration.getMillis, TimeUnit.MILLISECONDS),
               runnable = delayedTask)
           } else {
             val disableJob =
@@ -363,27 +404,40 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
             val newJob = {
               job match {
                 case job: ScheduleBasedJob =>
-                  job.copy(errorCount = job.errorCount + 1,
+                  job.copy(
+                    errorCount = job.errorCount + 1,
                     errorsSinceLastSuccess = job.errorsSinceLastSuccess + 1,
-                    lastError = lastErrorTime.toString, disabled = disableJob)
+                    lastError = lastErrorTime.toString,
+                    disabled = disableJob)
                 case job: DependencyBasedJob =>
-                  job.copy(errorCount = job.errorCount + 1,
+                  job.copy(
+                    errorCount = job.errorCount + 1,
                     errorsSinceLastSuccess = job.errorsSinceLastSuccess + 1,
-                    lastError = lastErrorTime.toString, disabled = disableJob)
-                case _ => throw new IllegalArgumentException("Cannot handle unknown task type")
+                    lastError = lastErrorTime.toString,
+                    disabled = disableJob)
+                case _ =>
+                  throw new IllegalArgumentException(
+                    "Cannot handle unknown task type")
               }
             }
             updateJob(job, newJob)
-            if (job.softError) processDependencies(jobName, Option(lastErrorTime))
+            if (job.softError)
+              processDependencies(jobName, Option(lastErrorTime))
 
             // Handle failure by either disabling the job and notifying the owner,
             // or just notifying the owner.
             if (disableJob) {
-              log.warning("JobSchedule failed beyond retries! JobSchedule will now be disabled after "
-                + newJob.errorsSinceLastSuccess + " failures (disableAfterFailures=" + disableAfterFailures + ").")
-              val msg = "\nFailed at '%s', %d failures since last success\nTask id: %s\n"
-                .format(DateTime.now(DateTimeZone.UTC), newJob.errorsSinceLastSuccess, taskId)
-              jobsObserver.apply(JobDisabled(job, TaskUtils.appendSchedulerMessage(msg, taskStatus)))
+              log.warning(
+                "JobSchedule failed beyond retries! JobSchedule will now be disabled after "
+                  + newJob.errorsSinceLastSuccess + " failures (disableAfterFailures=" + disableAfterFailures + ").")
+              val msg =
+                "\nFailed at '%s', %d failures since last success\nTask id: %s\n"
+                  .format(DateTime.now(DateTimeZone.UTC),
+                          newJob.errorsSinceLastSuccess,
+                          taskId)
+              jobsObserver.apply(
+                JobDisabled(job,
+                            TaskUtils.appendSchedulerMessage(msg, taskStatus)))
             } else {
               log.warning("JobSchedule failed beyond retries!")
               jobsObserver.apply(JobRetriesExhausted(job, taskStatus, attempt))
@@ -391,8 +445,9 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
             jobMetrics.updateJobStatus(jobName, success = false)
           }
         case None =>
-          log.warning("Could not find job for task: %s JobSchedule may have been deleted while task was in flight!"
-            .format(taskId))
+          log.warning(
+            "Could not find job for task: %s JobSchedule may have been deleted while task was in flight!"
+              .format(taskId))
       }
     }
   }
@@ -413,7 +468,11 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
     val (jobName, start, attempt, _) = TaskUtils.parseTaskId(taskId)
     val jobOption = jobGraph.lookupVertex(jobName)
 
-    jobsObserver.apply(JobFailed(jobOption.toRight(jobName), taskStatus, attempt, taskManager.getRunningTaskCount(jobName)))
+    jobsObserver.apply(
+      JobFailed(jobOption.toRight(jobName),
+                taskStatus,
+                attempt,
+                taskManager.getRunningTaskCount(jobName)))
   }
 
   //Begin Service interface
@@ -421,17 +480,20 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
     assert(!running.get, "This scheduler is already running!")
     log.info("Trying to become leader.")
 
-    leaderLatch.addListener(new LeaderLatchListener {
-      override def notLeader(): Unit = {
-        leader.set(false)
-        onDefeated()
-      }
+    leaderLatch.addListener(
+      new LeaderLatchListener {
+        override def notLeader(): Unit = {
+          leader.set(false)
+          onDefeated()
+        }
 
-      override def isLeader(): Unit = {
-        leader.set(true)
-        onElected()
-      }
-    }, leaderExecutor)
+        override def isLeader(): Unit = {
+          leader.set(true)
+          onElected()
+        }
+      },
+      leaderExecutor
+    )
     leaderLatch.start()
   }
 
@@ -453,13 +515,12 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
     val jobScheduler = this
     //Consider making this a background thread or control via an executor.
 
-    val f = localExecutor.submit(
-      new Thread() {
-        override def run() {
-          log.info("Running background thread")
-          jobScheduler.mainLoop()
-        }
-      })
+    val f = localExecutor.submit(new Thread() {
+      override def run() {
+        log.info("Running background thread")
+        jobScheduler.mainLoop()
+      }
+    })
 
     schedulerThreadFuture.set(f)
     log.info("Starting chronos driver")
@@ -467,7 +528,9 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
   }
 
   def mainLoop() {
-    log.info("Starting main loop for JobScheduler. CurrentTime: %s".format(DateTime.now(DateTimeZone.UTC)))
+    log.info(
+      "Starting main loop for JobScheduler. CurrentTime: %s".format(
+        DateTime.now(DateTimeZone.UTC)))
     var nanos = 1000000000l // 1 second
     while (running.get) {
       lock.lock()
@@ -484,7 +547,8 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
           val baseJobs = JobUtils.loadJobs(persistenceStore)
           val scheduledJobs = registerJobs(baseJobs)
           val (jobsToRun, jobsNotToRun) = getJobsToRun(scheduledJobs)
-          log.info(s"jobsToRun.size=${jobsToRun.size}, jobsNotToRun.size=${jobsNotToRun.size}")
+          log.info(
+            s"jobsToRun.size=${jobsToRun.size}, jobsNotToRun.size=${jobsNotToRun.size}")
           runJobs(jobsToRun)
           nanos = nanosUntilNextJob(jobsNotToRun)
         } catch {
@@ -500,7 +564,8 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
   def registerJobs(jobs: List[BaseJob]): List[ScheduleBasedJob] = {
     var scheduledJobList = List[ScheduleBasedJob]()
     lock.synchronized {
-      require(isLeader, "Cannot register a job with this scheduler, not the leader!")
+      require(isLeader,
+              "Cannot register a job with this scheduler, not the leader!")
       val scheduleBasedJobs = ListBuffer[ScheduleBasedJob]()
       val dependencyBasedJobs = ListBuffer[DependencyBasedJob]()
 
@@ -510,93 +575,96 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
         case x: ScheduleBasedJob =>
           scheduleBasedJobs += x
         case x: Any =>
-          throw new IllegalStateException("Error, job is neither ScheduleBased nor DependencyBased:" + x.toString)
+          throw new IllegalStateException(
+            "Error, job is neither ScheduleBased nor DependencyBased:" + x.toString)
       }
 
       if (scheduleBasedJobs.nonEmpty) {
         val newScheduledJobs = scheduleBasedJobs.sortWith({ (lhs, rhs) =>
-          JobUtils.getScheduledTime(lhs).isBefore(JobUtils.getScheduledTime(rhs))
+          JobUtils
+            .getScheduledTime(lhs)
+            .isBefore(JobUtils.getScheduledTime(rhs))
         })
-        scheduleBasedJobs.foreach({
-          job =>
-            jobGraph.lookupVertex(job.name) match {
-              case Some(_) =>
-                jobGraph.replaceVertex(job, job)
-              case _ =>
-                jobGraph.addVertex(job)
-            }
-        })
-        if (newScheduledJobs.nonEmpty) {
-          scheduledJobList = newScheduledJobs.toList
-        }
-      }
-
-      dependencyBasedJobs.foreach {
-        job =>
+        scheduleBasedJobs.foreach({ job =>
           jobGraph.lookupVertex(job.name) match {
             case Some(_) =>
               jobGraph.replaceVertex(job, job)
             case _ =>
               jobGraph.addVertex(job)
           }
+        })
+        if (newScheduledJobs.nonEmpty) {
+          scheduledJobList = newScheduledJobs.toList
+        }
       }
-      dependencyBasedJobs.foreach {
-        job =>
-          import scala.collection.JavaConversions._
-          log.info("Adding dependencies for %s -> [%s]".format(job.name, Joiner.on(",").join(job.parents)))
 
-          jobGraph.parentJobsOption(job) match {
-            case None =>
-              log.warning(s"Coudn't find all parents of job ${job.name}... dropping it.")
-              jobGraph.removeVertex(job)
-            case Some(parentJobs) =>
-              parentJobs.foreach {
-                //Setup all the dependencies
-                parentJob: BaseJob =>
-                  jobGraph.addDependency(parentJob.name, job.name)
-              }
-          }
+      dependencyBasedJobs.foreach { job =>
+        jobGraph.lookupVertex(job.name) match {
+          case Some(_) =>
+            jobGraph.replaceVertex(job, job)
+          case _ =>
+            jobGraph.addVertex(job)
+        }
+      }
+      dependencyBasedJobs.foreach { job =>
+        import scala.collection.JavaConversions._
+        log.info(
+          "Adding dependencies for %s -> [%s]"
+            .format(job.name, Joiner.on(",").join(job.parents)))
+
+        jobGraph.parentJobsOption(job) match {
+          case None =>
+            log.warning(
+              s"Coudn't find all parents of job ${job.name}... dropping it.")
+            jobGraph.removeVertex(job)
+          case Some(parentJobs) =>
+            parentJobs.foreach {
+              //Setup all the dependencies
+              parentJob: BaseJob =>
+                jobGraph.addDependency(parentJob.name, job.name)
+            }
+        }
       }
     }
     scheduledJobList
   }
 
   def nanosUntilNextJob(scheduledJobs: List[ScheduleBasedJob]): Long = {
-    scheduledJobs.foreach {
-      job =>
-        Iso8601Expressions.parse(job.schedule, job.scheduleTimeZone) match {
-          case Some((_, schedule, _)) =>
-            if (!job.disabled) {
-              val nanos = new Duration(DateTime.now(DateTimeZone.UTC), schedule).getMillis * 1000000
-              if (nanos > 0) {
-                return nanos
-              }
-              return 0
+    scheduledJobs.foreach { job =>
+      Iso8601Expressions.parse(job.schedule, job.scheduleTimeZone) match {
+        case Some((_, schedule, _)) =>
+          if (!job.disabled) {
+            val nanos = new Duration(DateTime.now(DateTimeZone.UTC), schedule).getMillis * 1000000
+            if (nanos > 0) {
+              return nanos
             }
-          case _ =>
-        }
+            return 0
+          }
+        case _ =>
+      }
     }
     60000000000l // 60 seconds
   }
 
-  def getJobsToRun(scheduledJobs: List[ScheduleBasedJob]): (List[ScheduleBasedJob], List[ScheduleBasedJob]) = {
+  def getJobsToRun(scheduledJobs: List[ScheduleBasedJob])
+    : (List[ScheduleBasedJob], List[ScheduleBasedJob]) = {
     val now = DateTime.now(DateTimeZone.UTC)
-    scheduledJobs.partition({
-      job =>
-        Iso8601Expressions.parse(job.schedule, job.scheduleTimeZone) match {
-          case Some((repeat, schedule, _)) =>
-            !job.disabled && repeat != 0 && schedule.isBefore(now)
-          case _ =>
-            false
-        }
+    scheduledJobs.partition({ job =>
+      Iso8601Expressions.parse(job.schedule, job.scheduleTimeZone) match {
+        case Some((repeat, schedule, _)) =>
+          !job.disabled && repeat != 0 && schedule.isBefore(now)
+        case _ =>
+          false
+      }
     })
   }
 
   final def runJobs(jobs: List[ScheduleBasedJob]) {
-    jobs.foreach {
-      job =>
-        log.info("Scheduling:" + job.name)
-        taskManager.enqueue(TaskUtils.getTaskId(job, DateTime.now(DateTimeZone.UTC)), job.highPriority)
+    jobs.foreach { job =>
+      log.info("Scheduling:" + job.name)
+      taskManager.enqueue(
+        TaskUtils.getTaskId(job, DateTime.now(DateTimeZone.UTC)),
+        job.highPriority)
     }
   }
 

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerSpec.scala
@@ -12,16 +12,24 @@ import scala.util.Random
 class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
   "JobScheduler" should {
     "Run the correct job" in {
-      val job1 = ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD")
-      val job2 = ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job2", "CMD", disabled = true)
+      val job1 =
+        ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD")
+      val job2 = ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D",
+                                  "job2",
+                                  "CMD",
+                                  disabled = true)
       val futureDate = DateTime.now().plusYears(1)
-      val job3 = ScheduleBasedJob(s"R5/${ISODateTimeFormat.dateTime().print(futureDate)}/P1D", "job3", "CMD")
+      val job3 = ScheduleBasedJob(
+        s"R5/${ISODateTimeFormat.dateTime().print(futureDate)}/P1D",
+        "job3",
+        "CMD")
 
       val jobGraph = mock[JobGraph]
       val persistenceStore = mock[PersistenceStore]
       val mockTaskManager = mock[TaskManager]
 
-      val scheduler = MockJobUtils.mockScheduler(mockTaskManager, jobGraph, persistenceStore)
+      val scheduler =
+        MockJobUtils.mockScheduler(mockTaskManager, jobGraph, persistenceStore)
 
       scheduler.leader.set(true)
       val scheduledJobs = scheduler.registerJobs(List(job1, job2, job3))
@@ -42,14 +50,16 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     }
 
     "Register dependent job correctly" in {
-      val job1 = ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD")
+      val job1 =
+        ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD")
       val job2 = DependencyBasedJob(Set("job1"), "job2", "CMD")
 
       val jobGraph = new JobGraph
       val persistenceStore = mock[PersistenceStore]
       val mockTaskManager = mock[TaskManager]
 
-      val scheduler = MockJobUtils.mockScheduler(mockTaskManager, jobGraph, persistenceStore)
+      val scheduler =
+        MockJobUtils.mockScheduler(mockTaskManager, jobGraph, persistenceStore)
 
       scheduler.leader.set(true)
       val jobs = List(job1, job2)
@@ -61,20 +71,28 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     }
 
     "Register jobs in correct order and enqueue them" in {
-      val job1 = ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD")
-      val job2 = ScheduleBasedJob("R5/2012-02-01T00:00:00.000Z/P1D", "job2", "CMD")
-      val job3 = ScheduleBasedJob("R5/2012-03-01T00:00:00.000Z/P1D", "job3", "CMD")
+      val job1 =
+        ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD")
+      val job2 =
+        ScheduleBasedJob("R5/2012-02-01T00:00:00.000Z/P1D", "job2", "CMD")
+      val job3 =
+        ScheduleBasedJob("R5/2012-03-01T00:00:00.000Z/P1D", "job3", "CMD")
       val futureDate = DateTime.now().plusYears(1)
-      val job4 = ScheduleBasedJob(s"R5/${ISODateTimeFormat.dateTime().print(futureDate)}/P1D", "job4", "CMD")
+      val job4 = ScheduleBasedJob(
+        s"R5/${ISODateTimeFormat.dateTime().print(futureDate)}/P1D",
+        "job4",
+        "CMD")
 
       val jobGraph = mock[JobGraph]
       val persistenceStore = mock[PersistenceStore]
       val mockTaskManager = mock[TaskManager]
 
-      val scheduler = MockJobUtils.mockScheduler(mockTaskManager, jobGraph, persistenceStore)
+      val scheduler =
+        MockJobUtils.mockScheduler(mockTaskManager, jobGraph, persistenceStore)
 
       scheduler.leader.set(true)
-      val scheduledJobs = scheduler.registerJobs(Random.shuffle(List(job1, job2, job3, job4)))
+      val scheduledJobs =
+        scheduler.registerJobs(Random.shuffle(List(job1, job2, job3, job4)))
       val (jobsToRun, jobsNotToRun) = scheduler.getJobsToRun(scheduledJobs)
       scheduler.runJobs(jobsToRun)
 
@@ -91,27 +109,41 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
         one(jobGraph).addVertex(job3) andThen
         one(jobGraph).addVertex(job4)
       there were 3.times(mockTaskManager).enqueue(anyString, anyBoolean)
-      there was one(mockTaskManager).enqueue(endingWith(":job3:"), anyBoolean) andThen
+      there was one(mockTaskManager)
+        .enqueue(endingWith(":job3:"), anyBoolean) andThen
         one(mockTaskManager).enqueue(endingWith(":job2:"), anyBoolean) andThen
         one(mockTaskManager).enqueue(endingWith(":job1:"), anyBoolean)
     }
 
     "Compute the correct amount of sleep time" in {
-      val job1 = ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD")
-      val job2 = ScheduleBasedJob("R5/2012-02-01T00:00:00.000Z/P1D", "job2", "CMD")
-      val job3 = ScheduleBasedJob("R5/2012-03-01T00:00:00.000Z/P1D", "job3", "CMD", disabled = true)
+      val job1 =
+        ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD")
+      val job2 =
+        ScheduleBasedJob("R5/2012-02-01T00:00:00.000Z/P1D", "job2", "CMD")
+      val job3 = ScheduleBasedJob("R5/2012-03-01T00:00:00.000Z/P1D",
+                                  "job3",
+                                  "CMD",
+                                  disabled = true)
       val futureDate1 = DateTime.now(DateTimeZone.UTC).plusHours(1)
-      val job4 = ScheduleBasedJob(s"R5/${ISODateTimeFormat.dateTime().print(futureDate1)}/P1D", "job4", "CMD")
+      val job4 = ScheduleBasedJob(
+        s"R5/${ISODateTimeFormat.dateTime().print(futureDate1)}/P1D",
+        "job4",
+        "CMD")
       val futureDate2 = DateTime.now(DateTimeZone.UTC).plusHours(2)
-      val job5 = ScheduleBasedJob(s"R5/${ISODateTimeFormat.dateTime().print(futureDate2)}/P1D", "job5", "CMD")
+      val job5 = ScheduleBasedJob(
+        s"R5/${ISODateTimeFormat.dateTime().print(futureDate2)}/P1D",
+        "job5",
+        "CMD")
 
       val jobGraph = mock[JobGraph]
       val persistenceStore = mock[PersistenceStore]
       val mockTaskManager = mock[TaskManager]
 
-      val scheduler = MockJobUtils.mockScheduler(mockTaskManager, jobGraph, persistenceStore)
+      val scheduler =
+        MockJobUtils.mockScheduler(mockTaskManager, jobGraph, persistenceStore)
 
-      var nanos = scheduler.nanosUntilNextJob(List(job1, job2, job3, job4, job5))
+      var nanos =
+        scheduler.nanosUntilNextJob(List(job1, job2, job3, job4, job5))
       nanos must_== 0
 
       nanos = scheduler.nanosUntilNextJob(List(job2, job3, job4, job5))
@@ -128,16 +160,19 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
     }
 
     "A parent job succeeds and child is enqueued" in {
-      val job1 = ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD")
+      val job1 =
+        ScheduleBasedJob("R5/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD")
       val job2 = DependencyBasedJob(Set("job1"), "job2", "CMD")
-      val job3 = DependencyBasedJob(Set("job1"), "job3", "CMD", disabled = true)
+      val job3 =
+        DependencyBasedJob(Set("job1"), "job3", "CMD", disabled = true)
       val job4 = DependencyBasedJob(Set("job2"), "job4", "CMD")
 
       val jobGraph = new JobGraph
       val persistenceStore = mock[PersistenceStore]
       val mockTaskManager = mock[TaskManager]
 
-      val scheduler = MockJobUtils.mockScheduler(mockTaskManager, jobGraph, persistenceStore)
+      val scheduler =
+        MockJobUtils.mockScheduler(mockTaskManager, jobGraph, persistenceStore)
 
       scheduler.leader.set(true)
       val jobs = List(job1, job2, job3, job4)
@@ -154,9 +189,26 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
       scheduler.markJobSuccessAndFireOffDependencies("job1")
       scheduler.markJobSuccessAndFireOffDependencies("job2")
 
-      there was one(mockTaskManager).enqueue(endWith(":job2:"), anyBoolean) andThen
+      there was one(mockTaskManager)
+        .enqueue(endWith(":job2:"), anyBoolean) andThen
         no(mockTaskManager).enqueue(endWith(":job3:"), anyBoolean) andThen
         one(mockTaskManager).enqueue(endWith(":job4:"), anyBoolean)
+    }
+
+    "A single repitition job doesn't fail" in {
+      val job1 =
+        ScheduleBasedJob("R1/2012-01-01T00:00:00.000Z/P1D", "job1", "CMD")
+
+      val jobGraph = new JobGraph
+      val persistenceStore = mock[PersistenceStore]
+      val mockTaskManager = mock[TaskManager]
+
+      val scheduler =
+        MockJobUtils.mockScheduler(mockTaskManager, jobGraph, persistenceStore)
+
+      val job2 = scheduler.getNewRunningJob(job1)
+
+      job1.name must_== job2.name
     }
   }
 }


### PR DESCRIPTION
When a job with a finite number of repetitions reaches its last
repition, it should stop (and not crash Chronos).

This fixes #772.