### PR TITLE
Fix for overdue jobs with finite recurrences.

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtils.scala
@@ -101,11 +101,8 @@ object JobUtils {
             new JobSchedule(Iso8601Expressions.create(rec, nStart, per),
                             job.name,
                             job.scheduleTimeZone))
-        } else if (rec < skip) {
-          log.warning("Filtered job as it is no longer valid.")
-          None
         } else {
-          val nRec = rec - (skip + 1)
+          val nRec = rec - 1
           val nStart = start.plus(per.multipliedBy(skip))
           log.warning(
             "Skipped forward %d iterations, iterations is now '%d' , modified start from '%s' to '%s"

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtilsSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobUtilsSpec.scala
@@ -146,6 +146,21 @@ class JobUtilsSpec extends SpecificationWithJUnit with Mockito {
     scheduledTime.toLocalDate must_== now.toLocalDate
   }
 
+  "Skip forward to current date and stop for R1 and PT1S" in {
+    val now = new DateTime()
+    val schedule = s"R1/${now.minusDays(1).toDateTimeISO.toString}/PT1S"
+    val job = ScheduleBasedJob(schedule, "sample-name", "sample-command")
+
+    // Get the schedule stream, which should have been skipped forward
+    val stream = JobUtils.skipForward(job, now)
+    val (repeat, scheduledTime, period) =
+      Iso8601Expressions.parse(stream.get.schedule, job.scheduleTimeZone).get
+
+    repeat must_== 0
+    period.toStandardSeconds.getSeconds must_== 1
+    scheduledTime.toLocalDate must_== now.toLocalDate
+  }
+
   "Can get job with arguments" in {
     val schedule = "R/2012-01-01T00:00:01.000Z/P1M"
     val arguments = "--help"


### PR DESCRIPTION
This is a follow-up to #789, which missed a case where the job is
overdue and has a finite number of recurrences.