### PR TITLE
Make chronos the PID 1

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-LIBPROCESS_PORT="${PORT1}" java $JVM_OPTS -jar /chronos/chronos.jar $@ --http_port $PORT0
+export LIBPROCESS_PORT="${PORT1}" 
+exec java $JVM_OPTS -jar /chronos/chronos.jar $@ --http_port $PORT0


### PR DESCRIPTION
By doing an `exec`, `java` becomes the PID 1 in the conatiner, making the chronos application receive `SIGTERM` signals sent by docker when executing a `docker stop` command.

See https://docs.docker.com/engine/reference/builder/#entrypoint for more details.