### PR TITLE
Don't persist additional job arguments.

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
@@ -173,14 +173,7 @@ class TaskManager @Inject()(
         jobsObserver.apply(JobExpired(jobOption.get, taskId))
         None
       } else {
-        val jobArguments = TaskUtils.getJobArgumentsForTaskId(taskId)
-        var job = jobOption.get
-
-        if (jobArguments != null && !jobArguments.isEmpty) {
-          job = JobUtils.getJobWithArguments(job, jobArguments)
-        }
-
-        Some(taskId, job)
+        Some(taskId, jobOption.get)
       }
     }
   }


### PR DESCRIPTION
Job arguments which are generated just before a job is launched should
not be persisted to the state store.

This resolves #779 and #794.