### PR TITLE
Add missing MESOS_TASK_ID environment variable

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosTaskBuilder.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosTaskBuilder.scala
@@ -138,6 +138,7 @@ class MesosTaskBuilder @Inject()(val conf: SchedulerConfiguration) {
     val (_, start, attempt, _) = TaskUtils.parseTaskId(taskIdStr)
     val baseEnv = Map(
       "mesos_task_id" -> taskIdStr,
+      "MESOS_TASK_ID" -> taskIdStr,
       "CHRONOS_JOB_OWNER" -> job.owner,
       "CHRONOS_JOB_NAME" -> job.name,
       "HOST" -> offer.getHostname,

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/mesos/MesosTaskBuilderSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/mesos/MesosTaskBuilderSpec.scala
@@ -51,6 +51,7 @@ class MesosTaskBuilderSpec extends SpecificationWithJUnit with Mockito {
 
   val defaultEnv = Map(
     "mesos_task_id" -> taskId,
+    "MESOS_TASK_ID" -> taskId,
     "CHRONOS_JOB_OWNER" -> job.owner,
     "CHRONOS_JOB_NAME" -> job.name,
     "HOST" -> offer.getHostname,


### PR DESCRIPTION
As `MESOS_TASK_ID` is an environment variable, it should be uppercase.