### PR TITLE
Fix for nanosUntilNextJob() edge case.

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/JobScheduler.scala
@@ -627,8 +627,8 @@ class JobScheduler @Inject()(val taskManager: TaskManager,
   def nanosUntilNextJob(scheduledJobs: List[ScheduleBasedJob]): Long = {
     scheduledJobs.foreach { job =>
       Iso8601Expressions.parse(job.schedule, job.scheduleTimeZone) match {
-        case Some((_, schedule, _)) =>
-          if (!job.disabled) {
+        case Some((repeat, schedule, _)) =>
+          if (!job.disabled && repeat != 0) {
             val nanos = new Duration(DateTime.now(DateTimeZone.UTC), schedule).getMillis * 1000000
             if (nanos > 0) {
               return nanos

--- a/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerSpec.scala
+++ b/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerSpec.scala
@@ -134,6 +134,10 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
         s"R5/${ISODateTimeFormat.dateTime().print(futureDate2)}/P1D",
         "job5",
         "CMD")
+      val jobNoRepititions = ScheduleBasedJob(
+        s"R0/${ISODateTimeFormat.dateTime().print(DateTime.now(DateTimeZone.UTC))}/P1D",
+        "job5",
+        "CMD")
 
       val jobGraph = mock[JobGraph]
       val persistenceStore = mock[PersistenceStore]
@@ -156,6 +160,9 @@ class JobSchedulerSpec extends SpecificationWithJUnit with Mockito {
       nanos must beCloseTo(60 * 60 * 1000000000l, 5000000000l) // within 5s
 
       nanos = scheduler.nanosUntilNextJob(List(job5))
+      nanos must beCloseTo(2 * 60 * 60 * 1000000000l, 5000000000l) // within 5s
+
+      nanos = scheduler.nanosUntilNextJob(List(jobNoRepititions, job5))
       nanos must beCloseTo(2 * 60 * 60 * 1000000000l, 5000000000l) // within 5s
     }
 


### PR DESCRIPTION
If a job has 0 repititions remaining, but the schedule is in the past,
it'll cause the sleep time to be return as 0. This might fix #803.