### PR TITLE
Ask for confirmation before taking action in job summary

### DIFF
--- a/src/main/resources/ui/components/JobSummaryView.js
+++ b/src/main/resources/ui/components/JobSummaryView.js
@@ -76,7 +76,7 @@ class JobSummaryView extends React.Component {
               className="btn btn-danger"
               aria-label="Delete"
               data-loading-text='<i class="fa fa-spinner fa-pulse fa-fw"></i>'
-              onClick={(event) => this.deleteJob(this, job)}
+              onClick={(event) => this.deleteJob(event, job)}
               title="Delete">
               <i className="fa fa-times" aria-hidden="true"></i>
             </button>

--- a/src/main/resources/ui/components/JobSummaryView.js
+++ b/src/main/resources/ui/components/JobSummaryView.js
@@ -120,6 +120,12 @@ class JobSummaryView extends React.Component {
     return ''
   }
 
+  confirmAction(event, job) {
+      var btn = event.currentTarget
+      var msg = btn.title + ' the job "' + job.name + '"?'
+      return window.confirm(msg)
+  }
+
   getStateClass(job) {
     if (job.state.match(/\d+ running/)) {
       return 'success'
@@ -153,31 +159,37 @@ class JobSummaryView extends React.Component {
   }
 
   runJob(event, job) {
-    this.doRequest(
-      event.currentTarget,
-      'PUT',
-      'v1/scheduler/job/' + encodeURIComponent(job.name)
-    )
+    if (this.confirmAction(event, job)) {
+      this.doRequest(
+        event.currentTarget,
+        'PUT',
+        'v1/scheduler/job/' + encodeURIComponent(job.name)
+      )
+    }
   }
 
   stopJob(event, job) {
-    this.doRequest(
-      event.currentTarget,
-      'DELETE',
-      'v1/scheduler/task/kill/' + encodeURIComponent(job.name)
-    )
+    if (this.confirmAction(event, job)) {
+      this.doRequest(
+        event.currentTarget,
+        'DELETE',
+        'v1/scheduler/task/kill/' + encodeURIComponent(job.name)
+      )
+    }
   }
 
   deleteJob(event, job) {
     let _job = job
-    this.doRequest(
-      event.currentTarget,
-      'DELETE',
-      'v1/scheduler/job/' + encodeURIComponent(job.name),
-      function(resp) {
-        _job.destroy()
-      }
-    )
+    if (this.confirmAction(event, job)) {
+      this.doRequest(
+        event.currentTarget,
+        'DELETE',
+        'v1/scheduler/job/' + encodeURIComponent(job.name),
+        function(resp) {
+          _job.destroy()
+        }
+      )
+    }
   }
 
   editJob(job) {


### PR DESCRIPTION
This is related to #816, putting a confirmation dialog before running/stopping/deleting jobs seems like a good idea. Not using any fancy react libraries just good ol' javascript.
I am not specially sure about 7cfe1f3900 but it _seems_ to work just fine, I believe it to be a typo because the function definition for ``deleteJob()`` in ln181 expects an event.