### PR TITLE
only record task launch with the offer used

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
@@ -168,7 +168,7 @@ class MesosJobFramework @Inject()(
           List(offer.getId).asJava,
           mesosTasks.asJava
         ))
-        for (task <- tasks) {
+        for (task <- subTasks) {
           val name = task._2.name
           taskManager.addTask(name, task._3.getSlaveId.getValue, task._1)
           scheduler.handleLaunchedTask(task._2)


### PR DESCRIPTION
This typo caused chronos to think that each task was being launched with each offer.