### PR TITLE
Configurable notification level

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -51,6 +51,8 @@ If you installed chronos via package, run `/usr/bin/chronos run_jar --help`.
                                             otherChronos instances and the
                                             Mesos master to communicate with
                                             this instance
+--notification_level  <arg>                 The notification level to use
+                                            (DISABLED | FAILURES | ALL)
 --http_address  <arg>                       The address to listen on for
                                             HTTP requests
 --http_compression                          (Default) Enable http

--- a/src/main/scala/org/apache/mesos/chronos/notification/NotificationLevel.scala
+++ b/src/main/scala/org/apache/mesos/chronos/notification/NotificationLevel.scala
@@ -1,0 +1,20 @@
+package org.apache.mesos.chronos.notification
+
+sealed trait NotificationLevel extends Ordered[NotificationLevel] {
+  def toInt: Int
+
+  def compare(that: NotificationLevel) = this.toInt.compare(that.toInt)
+}
+
+object NotificationLevel {
+  case object Disabled extends NotificationLevel { def toInt = 0 }
+  case object Failures extends NotificationLevel { def toInt = 1 }
+  case object All extends NotificationLevel { def toInt = 2 }
+
+  def apply(s: String): Option[NotificationLevel] = s match {
+    case "disabled" => Some(NotificationLevel.Disabled)
+    case "failures" => Some(NotificationLevel.Failures)
+    case "all" => Some(NotificationLevel.All)
+    case _ => None
+  }
+}

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/config/MainModule.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/config/MainModule.scala
@@ -82,7 +82,7 @@ class MainModule(val config: SchedulerConfiguration with HttpConf)
   @Singleton
   @Provides
   def provideJobsObservers(jobStats: JobStats, notificationClients: List[ActorRef]): JobsObserver.Observer = {
-    val notifier = new JobNotificationObserver(notificationClients, config.clusterName.get)
+    val notifier = new JobNotificationObserver(notificationClients, config.clusterName.get, config.notificationLevel)
     JobsObserver.composite(List(notifier.asObserver, jobStats.asObserver))
   }
 

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/config/SchedulerConfiguration.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/config/SchedulerConfiguration.scala
@@ -1,9 +1,10 @@
 package org.apache.mesos.chronos.scheduler.config
 
 import java.net.InetSocketAddress
+import java.util.logging.Logger
 
+import org.apache.mesos.chronos.notification.NotificationLevel
 import org.rogach.scallop.ScallopConf
-
 
 /**
   * Configuration values that may be parsed from a YAML file.
@@ -11,6 +12,7 @@ import org.rogach.scallop.ScallopConf
   * @author Florian Leibert (flo@leibert.de)
   */
 trait SchedulerConfiguration extends ScallopConf {
+  private[this] val log = Logger.getLogger(getClass.getName)
 
   lazy val master = opt[String]("master",
     descr = "The URL of the Mesos master",
@@ -49,6 +51,9 @@ trait SchedulerConfiguration extends ScallopConf {
   lazy val zooKeeperAuth = opt[String]("zk_auth",
     descr = "Authorization string for ZooKeeper",
     default = None)
+  lazy val notificationLevelString = opt[String]("notification_level",
+    descr = "The notification level to use (DISABLED | FAILURES | ALL)",
+    default = Some("ALL"))
   lazy val mailServer = opt[String]("mail_server",
     descr = "Address of the mailserver in server:port format",
     default = None)
@@ -151,4 +156,12 @@ trait SchedulerConfiguration extends ScallopConf {
   def zooKeeperStatePath = "%s/state".format(zooKeeperPath())
 
   def zooKeeperCandidatePath = "%s/candidate".format(zooKeeperPath())
+
+  def notificationLevel = {
+    val s = notificationLevelString()
+    NotificationLevel(s.toLowerCase).getOrElse {
+      log.warning("Unknown notification level '%s' provided, setting notification level to ALL".format(s))
+      NotificationLevel.All
+    }
+  }
 }


### PR DESCRIPTION
This PR adds basic notification level support. Three notification levels are provided: `DISABLED`, `FAILURES`, `ALL`. Currently the following notifications will be affected:

* `JobRemoved` - only sent if notification level is set to `ALL`
* `JobDisabled` - only sent if notification level is set to `ALL`
* `JobRetriesExhausted` - sent if notification level is set to `FAILURES` or `ALL`