### PR TITLE
removeTasksForSlave: fix logic to identify tasks running on slave

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/jobs/TaskManager.scala
@@ -130,7 +130,7 @@ class TaskManager @Inject()(
     val jobs = runningTasks.map {
       case (jobName, tasks) =>
         val remaining = tasks.filter { task =>
-          slaveId == task.slaveId
+          slaveId != task.slaveId
         }
         (jobName, remaining)
     }


### PR DESCRIPTION
I found this bug when I noticed to following:

1. reboot a mesos slave with slave ID X
2. the slave comes back up with slave ID Y
3. chronos successfully runs jobs on the slave
4. after --agent_reregister_timeout (default 10 mins) passes, mesos master sends SLAVE_LOST for slave ID X
5. chronos starts launching jobs that are already running