### PR TITLE
Updated to new official release for openJDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 ARG http_proxy
 ENV http_proxy ${http_proxy}
 


### PR DESCRIPTION
Hello,
docker java images are now deprecated (https://hub.docker.com/_/java/).
It's recommended now to use the openjdk image: https://hub.docker.com/_/openjdk/