### PR TITLE
missing ui dependency

### DIFF
--- a/src/main/resources/ui/package.json
+++ b/src/main/resources/ui/package.json
@@ -32,6 +32,7 @@
     "body-parser": "^1.15.2",
     "bootstrap": "^3.3.7",
     "brace": "^0.9.1",
+    "create-react-class":"^15.5.2",
     "eslint": "^3.10.2",
     "eslint-plugin-react": "^6.7.1",
     "express": "^4.14.0",


### PR DESCRIPTION
UI build is failing when building from a fresh clone (no pre-existing node_modules folder). 
create-react-class is now required by react-input-autosize.
https://github.com/JedWatson/react-input-autosize/pull/83 moves if form dev to peer dependencies, so I guess we have to add this dependency into our package.json.
Anyway, this changes fix the UI build.