### PR TITLE
remove manual job start args in app.md

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -99,10 +99,8 @@ You can manually start a job by issuing an HTTP request.
 
 * Endpoint: __/v1/scheduler/job__
 * Method: __PUT__
-* Query string parameters: `arguments` - optional string with a list of command line arguments that is appended to job's `command`
-  * If job's `shell` is `true`, `arguments` will be ignored.
 * Example: `curl -L -X PUT chronos-node:8080/v1/scheduler/job/request_event_counter_hourly`
-* Example: `curl -L -X PUT chronos-node:8080/v1/scheduler/job/job_name?arguments=-debug`
+* Example: `curl -L -X PUT chronos-node:8080/v1/scheduler/job/job_name`
 * Response: HTTP 204
 
 ## Marking a job as successful


### PR DESCRIPTION
These args are deprecated, as per [https://groups.google.com/forum/#!topic/chronos-scheduler/tInXkQWHAts](https://groups.google.com/forum/#!topic/chronos-scheduler/tInXkQWHAts)

It is also clear that they aren't being used in the code, see:
`val (_, start, attempt, _) = TaskUtils.parseTaskId(taskIdStr)`
`jobArguments` is being assigned to the unused `_` variable in all invocations of this method.