### PR TITLE
Don't kill executors sending a TASK_STARTING update.

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
@@ -197,10 +197,7 @@ class MesosJobFramework @Inject()(
   def statusUpdate(schedulerDriver: SchedulerDriver, taskStatus: TaskStatus) {
     val taskId = taskStatus.getTaskId.getValue
     taskStatus.getState match {
-      case TaskState.TASK_RUNNING =>
-        taskManager.updateRunningTask(taskStatus)
-        scheduler.handleStartedTask(taskStatus)
-      case TaskState.TASK_STAGING =>
+      case TaskState.TASK_RUNNING | TaskState.TASK_STAGING | TaskState.TASK_STARTING =>
         taskManager.updateRunningTask(taskStatus)
         scheduler.handleStartedTask(taskStatus)
       case _ =>


### PR DESCRIPTION
Since the dawn of Mesos, executors have had the option of sending a `TASK_STARTING` update to indicate that the launch command has been received. Currently, Chronos will react to to this update by killing the task.

As far as I can tell, this should fix the issue and tests are passing, but I will admit that I have no experience with either Scala or Maven.