### PR TITLE
Don't kill executors who send a TASK_STARTING update.

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/mesos/MesosJobFramework.scala
@@ -205,10 +205,7 @@ class MesosJobFramework @Inject()(
 
     val (jobName, _, _, _) = TaskUtils.parseTaskId(taskStatus.getTaskId.getValue)
     taskStatus.getState match {
-      case TaskState.TASK_RUNNING =>
-        scheduler.handleStartedTask(taskStatus)
-        updateRunningTask(jobName, taskStatus)
-      case TaskState.TASK_STAGING =>
+      case TaskState.TASK_RUNNING | TaskState.TASK_STAGING | TaskState.TASK_STARTING =>
         scheduler.handleStartedTask(taskStatus)
         updateRunningTask(jobName, taskStatus)
       case _ =>


### PR DESCRIPTION
This is the same change as in https://github.com/mesos/chronos/pull/854 , rebased onto the `stable` branch.